### PR TITLE
feat: add integration tests with DynamoDB Local

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,6 +2,7 @@ name: Build
 
 on:
   pull_request:
+  workflow_dispatch:
 
 jobs:
   build:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,6 +7,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
 
+    services:
+      dynamodb-local:
+        image: amazon/dynamodb-local:latest
+        ports:
+          - 8000:8000
+
     steps:
       - uses: actions/checkout@v4
 
@@ -17,5 +23,7 @@ jobs:
       - name: Build solution
         run: dotnet build
 
-      - name: Run unit-tests
+      - name: Run integration tests
+        env:
+          AWS_ENDPOINT_URL: http://localhost:8000
         run: dotnet test

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -4,6 +4,11 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageVersion Include="AWSSDK.DynamoDBv2" Version="4.0.18.5" />
+    <PackageVersion Include="coverlet.collector" Version="6.0.4" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
     <PackageVersion Include="OpenIddict.Core" Version="7.5.0" />
+    <PackageVersion Include="Testcontainers.DynamoDb" Version="4.6.0" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />
   </ItemGroup>
 </Project>

--- a/OpenIddict.DynamoDb.slnx
+++ b/OpenIddict.DynamoDb.slnx
@@ -1,5 +1,6 @@
 <Solution>
   <Folder Name="/src/">
     <Project Path="src/OpenIddict.DynamoDb/OpenIddict.DynamoDb.csproj" />
+    <Project Path="src/OpenIddict.DynamoDb.Tests/OpenIddict.DynamoDb.Tests.csproj" />
   </Folder>
 </Solution>

--- a/src/OpenIddict.DynamoDb.Tests/Fixtures/DynamoDbFixture.cs
+++ b/src/OpenIddict.DynamoDb.Tests/Fixtures/DynamoDbFixture.cs
@@ -1,0 +1,90 @@
+using Amazon.DynamoDBv2;
+using Amazon.Runtime;
+using Testcontainers.DynamoDb;
+
+namespace OpenIddict.DynamoDb.Tests.Fixtures;
+
+[CollectionDefinition(Name, DisableParallelization = true)]
+public sealed class DynamoDbCollection : ICollectionFixture<DynamoDbFixture>
+{
+    public const string Name = "DynamoDB Local";
+}
+
+public sealed class DynamoDbFixture : IAsyncLifetime
+{
+    private readonly DynamoDbContainer? _container;
+
+    public DynamoDbFixture()
+    {
+        if (string.IsNullOrWhiteSpace(Environment.GetEnvironmentVariable("AWS_ENDPOINT_URL")))
+        {
+            _container = new DynamoDbBuilder()
+                .WithImage("amazon/dynamodb-local:latest")
+                .Build();
+        }
+
+        var suffix = Guid.NewGuid().ToString("N");
+        Options = new OpenIddictDynamoDbOptions
+        {
+            ApplicationsTableName = $"OpenIddictApplications-{suffix}",
+            AuthorizationsTableName = $"OpenIddictAuthorizations-{suffix}",
+            ScopesTableName = $"OpenIddictScopes-{suffix}",
+            TokensTableName = $"OpenIddictTokens-{suffix}"
+        };
+    }
+
+    public IAmazonDynamoDB Client { get; private set; } = null!;
+
+    public OpenIddictDynamoDbOptions Options { get; }
+
+    public async Task InitializeAsync()
+    {
+        var endpointUrl = Environment.GetEnvironmentVariable("AWS_ENDPOINT_URL");
+
+        if (_container is not null)
+        {
+            await _container.StartAsync();
+            endpointUrl = _container.GetConnectionString();
+        }
+
+        var config = new AmazonDynamoDBConfig
+        {
+            AuthenticationRegion = "us-east-1",
+            ServiceURL = endpointUrl
+        };
+
+        Client = new AmazonDynamoDBClient(new BasicAWSCredentials("test", "test"), config);
+
+        // Wait for DynamoDB Local to be ready (CI service containers may not be immediately available)
+        await WaitForDynamoDbReadyAsync();
+
+        await OpenIddictDynamoDbTableCreator.CreateTablesAsync(Client, Options, CancellationToken.None);
+    }
+
+    private async Task WaitForDynamoDbReadyAsync(int maxRetries = 10, int delayMs = 1000)
+    {
+        for (var i = 0; i < maxRetries; i++)
+        {
+            try
+            {
+                await Client.ListTablesAsync(CancellationToken.None);
+                return;
+            }
+            catch
+            {
+                if (i == maxRetries - 1) throw;
+                await Task.Delay(delayMs);
+            }
+        }
+    }
+
+    public async Task DisposeAsync()
+    {
+        Client.Dispose();
+
+        if (_container is not null)
+        {
+            await _container.DisposeAsync();
+        }
+    }
+}

--- a/src/OpenIddict.DynamoDb.Tests/Fixtures/DynamoDbFixture.cs
+++ b/src/OpenIddict.DynamoDb.Tests/Fixtures/DynamoDbFixture.cs
@@ -80,7 +80,7 @@ public sealed class DynamoDbFixture : IAsyncLifetime
 
     public async Task DisposeAsync()
     {
-        Client.Dispose();
+        Client?.Dispose();
 
         if (_container is not null)
         {

--- a/src/OpenIddict.DynamoDb.Tests/Helpers/AsyncEnumerableExtensions.cs
+++ b/src/OpenIddict.DynamoDb.Tests/Helpers/AsyncEnumerableExtensions.cs
@@ -1,0 +1,16 @@
+namespace OpenIddict.DynamoDb.Tests.Helpers;
+
+public static class AsyncEnumerableExtensions
+{
+    public static async Task<List<T>> ToListAsync<T>(this IAsyncEnumerable<T> source)
+    {
+        var results = new List<T>();
+
+        await foreach (var item in source)
+        {
+            results.Add(item);
+        }
+
+        return results;
+    }
+}

--- a/src/OpenIddict.DynamoDb.Tests/Helpers/TestEntities.cs
+++ b/src/OpenIddict.DynamoDb.Tests/Helpers/TestEntities.cs
@@ -1,0 +1,100 @@
+using System.Text.Json;
+using OpenIddict.Abstractions;
+using OpenIddict.DynamoDb.Models;
+
+namespace OpenIddict.DynamoDb.Tests.Helpers;
+
+public static class TestEntities
+{
+    public static OpenIddictDynamoDbApplication CreateApplication(string? id = null, string? clientId = null)
+    {
+        var value = id ?? NewId("app");
+
+        return new OpenIddictDynamoDbApplication
+        {
+            Id = value,
+            ClientId = clientId ?? $"client-{value}",
+            ClientSecret = "secret",
+            ClientType = OpenIddictConstants.ClientTypes.Confidential,
+            ApplicationType = "web",
+            ConsentType = "explicit",
+            DisplayName = $"Application {value}",
+            Permissions = JsonArray(
+                OpenIddictConstants.Permissions.Prefixes.Endpoint + "authorization",
+                OpenIddictConstants.Permissions.Prefixes.Scope + "openid"),
+            RedirectUris = JsonArray($"https://example.com/{value}/callback"),
+            PostLogoutRedirectUris = JsonArray($"https://example.com/{value}/signout-callback"),
+            Requirements = JsonArray("pkce"),
+            Settings = "{\"setting\":\"value\"}",
+            Properties = "{\"property\":\"value\"}",
+            ConcurrencyToken = Guid.NewGuid().ToString()
+        };
+    }
+
+    public static OpenIddictDynamoDbAuthorization CreateAuthorization(
+        string? id = null,
+        string? applicationId = null,
+        string? subject = null)
+    {
+        var value = id ?? NewId("authz");
+
+        return new OpenIddictDynamoDbAuthorization
+        {
+            Id = value,
+            ApplicationId = applicationId ?? NewId("app"),
+            Subject = subject ?? $"subject-{value}",
+            Status = OpenIddictConstants.Statuses.Valid,
+            Type = OpenIddictConstants.AuthorizationTypes.Permanent,
+            Scopes = JsonArray("openid", "profile"),
+            CreationDate = DateTimeOffset.UtcNow,
+            Properties = "{\"property\":\"value\"}",
+            ConcurrencyToken = Guid.NewGuid().ToString()
+        };
+    }
+
+    public static OpenIddictDynamoDbScope CreateScope(string? id = null, string? name = null)
+    {
+        var value = id ?? NewId("scope");
+
+        return new OpenIddictDynamoDbScope
+        {
+            Id = value,
+            Name = name ?? $"scope-{value}",
+            Description = $"Description for {value}",
+            DisplayName = $"Scope {value}",
+            Resources = JsonArray("resource1", "resource2"),
+            Properties = "{\"property\":\"value\"}",
+            ConcurrencyToken = Guid.NewGuid().ToString()
+        };
+    }
+
+    public static OpenIddictDynamoDbToken CreateToken(
+        string? id = null,
+        string? applicationId = null,
+        string? authorizationId = null,
+        string? subject = null,
+        string? referenceId = null)
+    {
+        var value = id ?? NewId("token");
+
+        return new OpenIddictDynamoDbToken
+        {
+            Id = value,
+            ApplicationId = applicationId ?? NewId("app"),
+            AuthorizationId = authorizationId ?? NewId("authz"),
+            Subject = subject ?? $"subject-{value}",
+            ReferenceId = referenceId ?? $"reference-{value}",
+            Type = OpenIddictConstants.TokenTypeHints.AccessToken,
+            Status = OpenIddictConstants.Statuses.Valid,
+            CreationDate = DateTimeOffset.UtcNow,
+            ExpirationDate = DateTimeOffset.UtcNow.AddHours(1),
+            Payload = "payload",
+            Properties = "{\"property\":\"value\"}",
+            ConcurrencyToken = Guid.NewGuid().ToString()
+        };
+    }
+
+    public static string NewId(string prefix) => $"{prefix}-{Guid.NewGuid():N}";
+
+    public static string JsonArray(params string[] values) => JsonSerializer.Serialize(values);
+}

--- a/src/OpenIddict.DynamoDb.Tests/OpenIddict.DynamoDb.Tests.csproj
+++ b/src/OpenIddict.DynamoDb.Tests/OpenIddict.DynamoDb.Tests.csproj
@@ -1,30 +1,24 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
-        <ImplicitUsings>enable</ImplicitUsings>
-        <Nullable>enable</Nullable>
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
 
-        <IsPackable>false</IsPackable>
-        <IsTestProject>true</IsTestProject>
-    </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Testcontainers.DynamoDb" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <PackageReference Include="coverlet.collector" Version="6.0.0"/>
-        <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0"/>
-        <PackageReference Include="NSubstitute" Version="5.1.0" />
-        <PackageReference Include="Testcontainers" Version="3.9.0" />
-        <PackageReference Include="Testcontainers.DynamoDb" Version="3.9.0" />
-        <PackageReference Include="xunit" Version="2.5.3"/>
-        <PackageReference Include="xunit.runner.visualstudio" Version="2.5.3"/>
-    </ItemGroup>
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
 
-    <ItemGroup>
-        <Using Include="Xunit"/>
-    </ItemGroup>
-
-    <ItemGroup>
-      <ProjectReference Include="..\OpenIddict.DynamoDb\OpenIddict.DynamoDb.csproj" />
-    </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\OpenIddict.DynamoDb\OpenIddict.DynamoDb.csproj" />
+  </ItemGroup>
 
 </Project>

--- a/src/OpenIddict.DynamoDb.Tests/Stores/ApplicationStoreTests.cs
+++ b/src/OpenIddict.DynamoDb.Tests/Stores/ApplicationStoreTests.cs
@@ -345,7 +345,7 @@ public sealed class ApplicationStoreTests
     {
         var application = await CreateAndReloadApplicationAsync();
         var result = await _store.GetRequirementsAsync(application, CancellationToken.None);
-        Assert.Equal(ImmutableArray.Create("pkce"), result);
+        Assert.True(ImmutableArray.Create("pkce").SequenceEqual(result));
     }
 
     [Fact]
@@ -433,7 +433,7 @@ public sealed class ApplicationStoreTests
         var stored = await SetAndReloadApplicationAsync((application, token) => _store.SetPermissionsAsync(application, permissions, token));
 
         var result = await _store.GetPermissionsAsync(stored, CancellationToken.None);
-        Assert.Equal(permissions, result);
+        Assert.True(permissions.SequenceEqual(result));
     }
 
     [Fact]
@@ -444,7 +444,7 @@ public sealed class ApplicationStoreTests
         var stored = await SetAndReloadApplicationAsync((application, token) => _store.SetPostLogoutRedirectUrisAsync(application, uris, token));
 
         var result = await _store.GetPostLogoutRedirectUrisAsync(stored, CancellationToken.None);
-        Assert.Equal(uris, result);
+        Assert.True(uris.SequenceEqual(result));
         var applications = await _store.FindByPostLogoutRedirectUriAsync(uri, CancellationToken.None).ToListAsync();
         Assert.Single(applications);
         Assert.Equal(stored.Id, applications[0].Id);
@@ -469,7 +469,7 @@ public sealed class ApplicationStoreTests
         var stored = await SetAndReloadApplicationAsync((application, token) => _store.SetRedirectUrisAsync(application, uris, token));
 
         var result = await _store.GetRedirectUrisAsync(stored, CancellationToken.None);
-        Assert.Equal(uris, result);
+        Assert.True(uris.SequenceEqual(result));
         var applications = await _store.FindByRedirectUriAsync(uri, CancellationToken.None).ToListAsync();
         Assert.Single(applications);
         Assert.Equal(stored.Id, applications[0].Id);
@@ -482,7 +482,7 @@ public sealed class ApplicationStoreTests
         var stored = await SetAndReloadApplicationAsync((application, token) => _store.SetRequirementsAsync(application, requirements, token));
 
         var result = await _store.GetRequirementsAsync(stored, CancellationToken.None);
-        Assert.Equal(requirements, result);
+        Assert.True(requirements.SequenceEqual(result));
     }
 
     [Fact]

--- a/src/OpenIddict.DynamoDb.Tests/Stores/ApplicationStoreTests.cs
+++ b/src/OpenIddict.DynamoDb.Tests/Stores/ApplicationStoreTests.cs
@@ -1,8 +1,12 @@
 using Amazon.DynamoDBv2.Model;
+using Microsoft.IdentityModel.Tokens;
 using OpenIddict.Abstractions;
 using OpenIddict.DynamoDb.Models;
 using OpenIddict.DynamoDb.Tests.Fixtures;
 using OpenIddict.DynamoDb.Tests.Helpers;
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Text.Json;
 
 namespace OpenIddict.DynamoDb.Tests.Stores;
 
@@ -176,6 +180,425 @@ public sealed class ApplicationStoreTests
             () => _store.DeleteAsync(application, CancellationToken.None).AsTask());
 
         AssertDynamoDbConcurrencyFailure(exception);
+    }
+
+    [Fact]
+    public async Task FindByRedirectUriAsync_ReturnsMatchingApplications()
+    {
+        var redirectUri = $"https://example.com/{Guid.NewGuid():N}/callback";
+        var application = TestEntities.CreateApplication();
+        application.RedirectUris = TestEntities.JsonArray(redirectUri);
+        await _store.CreateAsync(application, CancellationToken.None);
+
+        var applications = await _store.FindByRedirectUriAsync(redirectUri, CancellationToken.None).ToListAsync();
+
+        Assert.Single(applications);
+        Assert.Equal(application.Id, applications[0].Id);
+    }
+
+    [Fact]
+    public async Task FindByPostLogoutRedirectUriAsync_ReturnsMatchingApplications()
+    {
+        var uri = $"https://example.com/{Guid.NewGuid():N}/signout-callback";
+        var application = TestEntities.CreateApplication();
+        application.PostLogoutRedirectUris = TestEntities.JsonArray(uri);
+        await _store.CreateAsync(application, CancellationToken.None);
+
+        var applications = await _store.FindByPostLogoutRedirectUriAsync(uri, CancellationToken.None).ToListAsync();
+
+        Assert.Single(applications);
+        Assert.Equal(application.Id, applications[0].Id);
+    }
+
+    [Fact]
+    public async Task InstantiateAsync_ReturnsNewInstance()
+    {
+        var application = await _store.InstantiateAsync(CancellationToken.None);
+
+        Assert.NotNull(application);
+        Assert.NotNull(application.ConcurrencyToken);
+        Assert.NotEmpty(application.ConcurrencyToken);
+    }
+
+    [Fact]
+    public async Task GetApplicationTypeAsync_ReturnsApplicationType()
+    {
+        var application = await CreateAndReloadApplicationAsync();
+        var result = await _store.GetApplicationTypeAsync(application, CancellationToken.None);
+        Assert.Equal(application.ApplicationType, result);
+    }
+
+    [Fact]
+    public async Task GetClientIdAsync_ReturnsClientId()
+    {
+        var application = await CreateAndReloadApplicationAsync();
+        var result = await _store.GetClientIdAsync(application, CancellationToken.None);
+        Assert.Equal(application.ClientId, result);
+    }
+
+    [Fact]
+    public async Task GetClientSecretAsync_ReturnsClientSecret()
+    {
+        var application = await CreateAndReloadApplicationAsync();
+        var result = await _store.GetClientSecretAsync(application, CancellationToken.None);
+        Assert.Equal(application.ClientSecret, result);
+    }
+
+    [Fact]
+    public async Task GetClientTypeAsync_ReturnsClientType()
+    {
+        var application = await CreateAndReloadApplicationAsync();
+        var result = await _store.GetClientTypeAsync(application, CancellationToken.None);
+        Assert.Equal(application.ClientType, result);
+    }
+
+    [Fact]
+    public async Task GetConsentTypeAsync_ReturnsConsentType()
+    {
+        var application = await CreateAndReloadApplicationAsync();
+        var result = await _store.GetConsentTypeAsync(application, CancellationToken.None);
+        Assert.Equal(application.ConsentType, result);
+    }
+
+    [Fact]
+    public async Task GetDisplayNameAsync_ReturnsDisplayName()
+    {
+        var application = await CreateAndReloadApplicationAsync();
+        var result = await _store.GetDisplayNameAsync(application, CancellationToken.None);
+        Assert.Equal(application.DisplayName, result);
+    }
+
+    [Fact]
+    public async Task GetDisplayNamesAsync_ReturnsDeserializedDictionary()
+    {
+        var application = TestEntities.CreateApplication();
+        var names = ImmutableDictionary.CreateBuilder<CultureInfo, string>();
+        names[CultureInfo.GetCultureInfo("en")] = "English Name";
+        names[CultureInfo.GetCultureInfo("fr")] = "French Name";
+        await _store.SetDisplayNamesAsync(application, names.ToImmutable(), CancellationToken.None);
+        await _store.CreateAsync(application, CancellationToken.None);
+        var stored = await _store.FindByIdAsync(application.Id, CancellationToken.None);
+
+        var result = await _store.GetDisplayNamesAsync(stored!, CancellationToken.None);
+
+        Assert.Equal("English Name", result[CultureInfo.GetCultureInfo("en")]);
+        Assert.Equal("French Name", result[CultureInfo.GetCultureInfo("fr")]);
+    }
+
+    [Fact]
+    public async Task GetIdAsync_ReturnsId()
+    {
+        var application = await CreateAndReloadApplicationAsync();
+        var result = await _store.GetIdAsync(application, CancellationToken.None);
+        Assert.Equal(application.Id, result);
+    }
+
+    [Fact]
+    public async Task GetJsonWebKeySetAsync_ReturnsDeserializedJsonWebKeySet()
+    {
+        var application = TestEntities.CreateApplication();
+        await _store.SetJsonWebKeySetAsync(application, new JsonWebKeySet("{\"keys\":[]}"), CancellationToken.None);
+        await _store.CreateAsync(application, CancellationToken.None);
+        var stored = await _store.FindByIdAsync(application.Id, CancellationToken.None);
+
+        var result = await _store.GetJsonWebKeySetAsync(stored!, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Empty(result.Keys);
+    }
+
+    [Fact]
+    public async Task GetPermissionsAsync_ReturnsDeserializedArray()
+    {
+        var application = await CreateAndReloadApplicationAsync();
+        var result = await _store.GetPermissionsAsync(application, CancellationToken.None);
+        Assert.Contains(OpenIddictConstants.Permissions.Prefixes.Endpoint + "authorization", result);
+        Assert.Contains(OpenIddictConstants.Permissions.Prefixes.Scope + "openid", result);
+    }
+
+    [Fact]
+    public async Task GetPostLogoutRedirectUrisAsync_ReturnsDeserializedArray()
+    {
+        var application = await CreateAndReloadApplicationAsync();
+        var result = await _store.GetPostLogoutRedirectUrisAsync(application, CancellationToken.None);
+        Assert.Contains($"https://example.com/{application.Id}/signout-callback", result);
+    }
+
+    [Fact]
+    public async Task GetPropertiesAsync_ReturnsDeserializedDictionary()
+    {
+        var application = await CreateAndReloadApplicationAsync();
+        var result = await _store.GetPropertiesAsync(application, CancellationToken.None);
+        Assert.Equal("value", result["property"].GetString());
+    }
+
+    [Fact]
+    public async Task GetRedirectUrisAsync_ReturnsDeserializedArray()
+    {
+        var application = await CreateAndReloadApplicationAsync();
+        var result = await _store.GetRedirectUrisAsync(application, CancellationToken.None);
+        Assert.Contains($"https://example.com/{application.Id}/callback", result);
+    }
+
+    [Fact]
+    public async Task GetRequirementsAsync_ReturnsDeserializedArray()
+    {
+        var application = await CreateAndReloadApplicationAsync();
+        var result = await _store.GetRequirementsAsync(application, CancellationToken.None);
+        Assert.Equal(ImmutableArray.Create("pkce"), result);
+    }
+
+    [Fact]
+    public async Task GetSettingsAsync_ReturnsDeserializedDictionary()
+    {
+        var application = await CreateAndReloadApplicationAsync();
+        var result = await _store.GetSettingsAsync(application, CancellationToken.None);
+        Assert.Equal("value", result["setting"]);
+    }
+
+    [Fact]
+    public async Task SetApplicationTypeAsync_UpdatesApplicationType()
+    {
+        var stored = await SetAndReloadApplicationAsync((application, token) => _store.SetApplicationTypeAsync(application, "native", token));
+        Assert.Equal("native", stored.ApplicationType);
+    }
+
+    [Fact]
+    public async Task SetClientIdAsync_UpdatesClientId()
+    {
+        var clientId = TestEntities.NewId("client");
+        var stored = await SetAndReloadApplicationAsync((application, token) => _store.SetClientIdAsync(application, clientId, token));
+
+        Assert.Equal(clientId, stored.ClientId);
+        var found = await _store.FindByClientIdAsync(clientId, CancellationToken.None);
+        Assert.NotNull(found);
+        Assert.Equal(stored.Id, found.Id);
+    }
+
+    [Fact]
+    public async Task SetClientSecretAsync_UpdatesClientSecret()
+    {
+        var stored = await SetAndReloadApplicationAsync((application, token) => _store.SetClientSecretAsync(application, "new-secret", token));
+        Assert.Equal("new-secret", stored.ClientSecret);
+    }
+
+    [Fact]
+    public async Task SetClientTypeAsync_UpdatesClientType()
+    {
+        var stored = await SetAndReloadApplicationAsync((application, token) => _store.SetClientTypeAsync(application, OpenIddictConstants.ClientTypes.Public, token));
+        Assert.Equal(OpenIddictConstants.ClientTypes.Public, stored.ClientType);
+    }
+
+    [Fact]
+    public async Task SetConsentTypeAsync_UpdatesConsentType()
+    {
+        var stored = await SetAndReloadApplicationAsync((application, token) => _store.SetConsentTypeAsync(application, OpenIddictConstants.ConsentTypes.Implicit, token));
+        Assert.Equal(OpenIddictConstants.ConsentTypes.Implicit, stored.ConsentType);
+    }
+
+    [Fact]
+    public async Task SetDisplayNameAsync_UpdatesDisplayName()
+    {
+        var stored = await SetAndReloadApplicationAsync((application, token) => _store.SetDisplayNameAsync(application, "New Display Name", token));
+        Assert.Equal("New Display Name", stored.DisplayName);
+    }
+
+    [Fact]
+    public async Task SetDisplayNamesAsync_UpdatesDisplayNames()
+    {
+        var names = ImmutableDictionary.CreateBuilder<CultureInfo, string>();
+        names[CultureInfo.GetCultureInfo("en")] = "English Name";
+        names[CultureInfo.GetCultureInfo("de")] = "German Name";
+        var stored = await SetAndReloadApplicationAsync((application, token) => _store.SetDisplayNamesAsync(application, names.ToImmutable(), token));
+
+        var result = await _store.GetDisplayNamesAsync(stored, CancellationToken.None);
+        Assert.Equal("English Name", result[CultureInfo.GetCultureInfo("en")]);
+        Assert.Equal("German Name", result[CultureInfo.GetCultureInfo("de")]);
+    }
+
+    [Fact]
+    public async Task SetJsonWebKeySetAsync_UpdatesJsonWebKeySet()
+    {
+        var stored = await SetAndReloadApplicationAsync((application, token) => _store.SetJsonWebKeySetAsync(application, new JsonWebKeySet("{\"keys\":[]}"), token));
+
+        var result = await _store.GetJsonWebKeySetAsync(stored, CancellationToken.None);
+        Assert.NotNull(result);
+        Assert.Empty(result.Keys);
+    }
+
+    [Fact]
+    public async Task SetPermissionsAsync_UpdatesPermissions()
+    {
+        var permissions = ImmutableArray.Create("endpoint:token", "grant_type:client_credentials");
+        var stored = await SetAndReloadApplicationAsync((application, token) => _store.SetPermissionsAsync(application, permissions, token));
+
+        var result = await _store.GetPermissionsAsync(stored, CancellationToken.None);
+        Assert.Equal(permissions, result);
+    }
+
+    [Fact]
+    public async Task SetPostLogoutRedirectUrisAsync_UpdatesPostLogoutRedirectUris()
+    {
+        var uri = $"https://example.com/{Guid.NewGuid():N}/logout";
+        var uris = ImmutableArray.Create(uri);
+        var stored = await SetAndReloadApplicationAsync((application, token) => _store.SetPostLogoutRedirectUrisAsync(application, uris, token));
+
+        var result = await _store.GetPostLogoutRedirectUrisAsync(stored, CancellationToken.None);
+        Assert.Equal(uris, result);
+        var applications = await _store.FindByPostLogoutRedirectUriAsync(uri, CancellationToken.None).ToListAsync();
+        Assert.Single(applications);
+        Assert.Equal(stored.Id, applications[0].Id);
+    }
+
+    [Fact]
+    public async Task SetPropertiesAsync_UpdatesProperties()
+    {
+        using var doc = JsonDocument.Parse("{\"NewProp\":\"NewVal\"}");
+        var properties = ImmutableDictionary.CreateRange(new[] { KeyValuePair.Create("NewProp", doc.RootElement) });
+        var stored = await SetAndReloadApplicationAsync((application, token) => _store.SetPropertiesAsync(application, properties, token));
+
+        var result = await _store.GetPropertiesAsync(stored, CancellationToken.None);
+        Assert.Equal("NewVal", result["NewProp"].GetString());
+    }
+
+    [Fact]
+    public async Task SetRedirectUrisAsync_UpdatesRedirectUris()
+    {
+        var uri = $"https://example.com/{Guid.NewGuid():N}/callback";
+        var uris = ImmutableArray.Create(uri);
+        var stored = await SetAndReloadApplicationAsync((application, token) => _store.SetRedirectUrisAsync(application, uris, token));
+
+        var result = await _store.GetRedirectUrisAsync(stored, CancellationToken.None);
+        Assert.Equal(uris, result);
+        var applications = await _store.FindByRedirectUriAsync(uri, CancellationToken.None).ToListAsync();
+        Assert.Single(applications);
+        Assert.Equal(stored.Id, applications[0].Id);
+    }
+
+    [Fact]
+    public async Task SetRequirementsAsync_UpdatesRequirements()
+    {
+        var requirements = ImmutableArray.Create("pkce", "mfa");
+        var stored = await SetAndReloadApplicationAsync((application, token) => _store.SetRequirementsAsync(application, requirements, token));
+
+        var result = await _store.GetRequirementsAsync(stored, CancellationToken.None);
+        Assert.Equal(requirements, result);
+    }
+
+    [Fact]
+    public async Task SetSettingsAsync_UpdatesSettings()
+    {
+        var settings = ImmutableDictionary.CreateRange(new[]
+        {
+            KeyValuePair.Create("setting", "new-value"),
+            KeyValuePair.Create("another", "value")
+        });
+        var stored = await SetAndReloadApplicationAsync((application, token) => _store.SetSettingsAsync(application, settings, token));
+
+        var result = await _store.GetSettingsAsync(stored, CancellationToken.None);
+        Assert.Equal("new-value", result["setting"]);
+        Assert.Equal("value", result["another"]);
+    }
+
+    [Fact]
+    public async Task CountAsync_WithIQueryable_ThrowsNotSupportedException()
+    {
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => _store.CountAsync<OpenIddictDynamoDbApplication>(q => q, CancellationToken.None).AsTask());
+    }
+
+    [Fact]
+    public async Task GetAsync_ThrowsNotSupportedException()
+    {
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => _store.GetAsync<object, string>((q, s) => q.Select(_ => _.Id), "state", CancellationToken.None).AsTask());
+    }
+
+    [Fact]
+    public async Task ListAsync_WithIQueryable_ThrowsNotSupportedException()
+    {
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => _store.ListAsync<object, string>((q, s) => q.Select(_ => _.Id), "state", CancellationToken.None).ToListAsync());
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ChangingClientId_OldClientIdLookupStopsResolving()
+    {
+        var application = TestEntities.CreateApplication();
+        await _store.CreateAsync(application, CancellationToken.None);
+
+        var oldClientId = application.ClientId!;
+        var newClientId = TestEntities.NewId("new-client");
+        await _store.SetClientIdAsync(application, newClientId, CancellationToken.None);
+        await _store.UpdateAsync(application, CancellationToken.None);
+
+        var byOld = await _store.FindByClientIdAsync(oldClientId, CancellationToken.None);
+        Assert.Null(byOld);
+
+        var byNew = await _store.FindByClientIdAsync(newClientId, CancellationToken.None);
+        Assert.NotNull(byNew);
+        Assert.Equal(application.Id, byNew.Id);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_ChangingRedirectUris_OldUriLookupStopsResolving()
+    {
+        var oldUri = $"https://example.com/{Guid.NewGuid():N}/callback";
+        var application = TestEntities.CreateApplication();
+        application.RedirectUris = TestEntities.JsonArray(oldUri);
+        await _store.CreateAsync(application, CancellationToken.None);
+
+        var newUri = $"https://example.com/{Guid.NewGuid():N}/callback";
+        await _store.SetRedirectUrisAsync(application, ImmutableArray.Create(newUri), CancellationToken.None);
+        await _store.UpdateAsync(application, CancellationToken.None);
+
+        var byOldUri = await _store.FindByRedirectUriAsync(oldUri, CancellationToken.None).ToListAsync();
+        Assert.Empty(byOldUri);
+
+        var byNewUri = await _store.FindByRedirectUriAsync(newUri, CancellationToken.None).ToListAsync();
+        Assert.Single(byNewUri);
+        Assert.Equal(application.Id, byNewUri[0].Id);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_CleansUpAllLookups()
+    {
+        var redirectUri = $"https://example.com/{Guid.NewGuid():N}/callback";
+        var postLogoutUri = $"https://example.com/{Guid.NewGuid():N}/signout-callback";
+        var application = TestEntities.CreateApplication();
+        application.RedirectUris = TestEntities.JsonArray(redirectUri);
+        application.PostLogoutRedirectUris = TestEntities.JsonArray(postLogoutUri);
+        await _store.CreateAsync(application, CancellationToken.None);
+
+        await _store.DeleteAsync(application, CancellationToken.None);
+
+        Assert.Null(await _store.FindByClientIdAsync(application.ClientId!, CancellationToken.None));
+        Assert.Empty(await _store.FindByRedirectUriAsync(redirectUri, CancellationToken.None).ToListAsync());
+        Assert.Empty(await _store.FindByPostLogoutRedirectUriAsync(postLogoutUri, CancellationToken.None).ToListAsync());
+    }
+
+    private async Task<OpenIddictDynamoDbApplication> CreateAndReloadApplicationAsync()
+    {
+        var application = TestEntities.CreateApplication();
+        await _store.CreateAsync(application, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(application.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        return stored;
+    }
+
+    private async Task<OpenIddictDynamoDbApplication> SetAndReloadApplicationAsync(
+        Func<OpenIddictDynamoDbApplication, CancellationToken, ValueTask> setter)
+    {
+        var application = TestEntities.CreateApplication();
+        await _store.CreateAsync(application, CancellationToken.None);
+
+        await setter(application, CancellationToken.None);
+        await _store.UpdateAsync(application, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(application.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        return stored;
     }
 
     private async Task<OpenIddictDynamoDbApplicationStore<OpenIddictDynamoDbApplication>> CreateEmptyStoreAsync()

--- a/src/OpenIddict.DynamoDb.Tests/Stores/ApplicationStoreTests.cs
+++ b/src/OpenIddict.DynamoDb.Tests/Stores/ApplicationStoreTests.cs
@@ -1,0 +1,199 @@
+using Amazon.DynamoDBv2.Model;
+using OpenIddict.Abstractions;
+using OpenIddict.DynamoDb.Models;
+using OpenIddict.DynamoDb.Tests.Fixtures;
+using OpenIddict.DynamoDb.Tests.Helpers;
+
+namespace OpenIddict.DynamoDb.Tests.Stores;
+
+[Collection(DynamoDbCollection.Name)]
+public sealed class ApplicationStoreTests
+{
+    private readonly OpenIddictDynamoDbApplicationStore<OpenIddictDynamoDbApplication> _store;
+    private readonly DynamoDbFixture _fixture;
+
+    public ApplicationStoreTests(DynamoDbFixture fixture)
+    {
+        _store = new OpenIddictDynamoDbApplicationStore<OpenIddictDynamoDbApplication>(fixture.Client, fixture.Options);
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task CreateAsync_StoresApplication()
+    {
+        var application = TestEntities.CreateApplication();
+
+        await _store.CreateAsync(application, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(application.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        Assert.Equal(application.ClientId, stored.ClientId);
+    }
+
+    [Fact]
+    public async Task FindByIdAsync_ReturnsApplication()
+    {
+        var application = TestEntities.CreateApplication();
+        await _store.CreateAsync(application, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(application.Id, CancellationToken.None);
+
+        Assert.NotNull(stored);
+        Assert.Equal(application.Id, stored.Id);
+    }
+
+    [Fact]
+    public async Task FindByClientIdAsync_ReturnsApplication()
+    {
+        var application = TestEntities.CreateApplication(clientId: TestEntities.NewId("client"));
+        await _store.CreateAsync(application, CancellationToken.None);
+
+        var stored = await _store.FindByClientIdAsync(application.ClientId!, CancellationToken.None);
+
+        Assert.NotNull(stored);
+        Assert.Equal(application.Id, stored.Id);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_PersistsDisplayName()
+    {
+        var application = TestEntities.CreateApplication();
+        await _store.CreateAsync(application, CancellationToken.None);
+
+        application.DisplayName = "Updated application";
+        await _store.UpdateAsync(application, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(application.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        Assert.Equal("Updated application", stored.DisplayName);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RemovesApplication()
+    {
+        var application = TestEntities.CreateApplication();
+        await _store.CreateAsync(application, CancellationToken.None);
+
+        await _store.DeleteAsync(application, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(application.Id, CancellationToken.None);
+        Assert.Null(stored);
+    }
+
+    [Fact]
+    public async Task ListAsync_ReturnsCreatedApplications()
+    {
+        var first = TestEntities.CreateApplication();
+        var second = TestEntities.CreateApplication();
+        await _store.CreateAsync(first, CancellationToken.None);
+        await _store.CreateAsync(second, CancellationToken.None);
+
+        var applications = await _store.ListAsync(count: null, offset: null, CancellationToken.None).ToListAsync();
+
+        Assert.Contains(applications, application => application.Id == first.Id);
+        Assert.Contains(applications, application => application.Id == second.Id);
+    }
+
+    [Fact]
+    public async Task CountAsync_IncludesCreatedApplications()
+    {
+        var before = await _store.CountAsync(CancellationToken.None);
+        await _store.CreateAsync(TestEntities.CreateApplication(), CancellationToken.None);
+        await _store.CreateAsync(TestEntities.CreateApplication(), CancellationToken.None);
+
+        var after = await _store.CountAsync(CancellationToken.None);
+
+        Assert.Equal(before + 2, after);
+    }
+    [Fact]
+    public async Task FindByIdAsync_NotFound_ReturnsNull()
+    {
+        var result = await _store.FindByIdAsync("nonexistent-id", CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task FindByClientIdAsync_NotFound_ReturnsNull()
+    {
+        var result = await _store.FindByClientIdAsync("nonexistent-client", CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task CountAsync_EmptyTable_ReturnsZero()
+    {
+        var store = await CreateEmptyStoreAsync();
+
+        var count = await store.CountAsync(CancellationToken.None);
+
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public async Task ListAsync_EmptyTable_ReturnsEmpty()
+    {
+        var store = await CreateEmptyStoreAsync();
+
+        var applications = await store.ListAsync(count: null, offset: null, CancellationToken.None).ToListAsync();
+
+        Assert.Empty(applications);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_StaleConcurrencyToken_Throws()
+    {
+        var application = TestEntities.CreateApplication();
+        await _store.CreateAsync(application, CancellationToken.None);
+
+        var originalToken = application.ConcurrencyToken;
+
+        application.DisplayName = "Updated application";
+        await _store.UpdateAsync(application, CancellationToken.None);
+
+        application.ConcurrencyToken = originalToken;
+        application.DisplayName = "Should fail";
+        var exception = await Assert.ThrowsAsync<OpenIddictExceptions.ConcurrencyException>(
+            () => _store.UpdateAsync(application, CancellationToken.None).AsTask());
+
+        AssertDynamoDbConcurrencyFailure(exception);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_StaleConcurrencyToken_Throws()
+    {
+        var application = TestEntities.CreateApplication();
+        await _store.CreateAsync(application, CancellationToken.None);
+
+        var originalToken = application.ConcurrencyToken;
+
+        application.DisplayName = "Updated application";
+        await _store.UpdateAsync(application, CancellationToken.None);
+
+        application.ConcurrencyToken = originalToken;
+        var exception = await Assert.ThrowsAsync<OpenIddictExceptions.ConcurrencyException>(
+            () => _store.DeleteAsync(application, CancellationToken.None).AsTask());
+
+        AssertDynamoDbConcurrencyFailure(exception);
+    }
+
+    private async Task<OpenIddictDynamoDbApplicationStore<OpenIddictDynamoDbApplication>> CreateEmptyStoreAsync()
+    {
+        var options = new OpenIddictDynamoDbOptions
+        {
+            ApplicationsTableName = $"{_fixture.Options.ApplicationsTableName}-empty-{Guid.NewGuid():N}",
+            AuthorizationsTableName = $"{_fixture.Options.AuthorizationsTableName}-empty-{Guid.NewGuid():N}",
+            ScopesTableName = $"{_fixture.Options.ScopesTableName}-empty-{Guid.NewGuid():N}",
+            TokensTableName = $"{_fixture.Options.TokensTableName}-empty-{Guid.NewGuid():N}"
+        };
+
+        await OpenIddictDynamoDbTableCreator.CreateTablesAsync(_fixture.Client, options, CancellationToken.None);
+
+        return new OpenIddictDynamoDbApplicationStore<OpenIddictDynamoDbApplication>(_fixture.Client, options);
+    }
+
+    private static void AssertDynamoDbConcurrencyFailure(OpenIddictExceptions.ConcurrencyException exception)
+        => Assert.True(exception.InnerException is ConditionalCheckFailedException or TransactionCanceledException);
+
+}

--- a/src/OpenIddict.DynamoDb.Tests/Stores/AuthorizationStoreTests.cs
+++ b/src/OpenIddict.DynamoDb.Tests/Stores/AuthorizationStoreTests.cs
@@ -3,6 +3,8 @@ using OpenIddict.Abstractions;
 using OpenIddict.DynamoDb.Models;
 using OpenIddict.DynamoDb.Tests.Fixtures;
 using OpenIddict.DynamoDb.Tests.Helpers;
+using System.Collections.Immutable;
+using System.Text.Json;
 
 namespace OpenIddict.DynamoDb.Tests.Stores;
 
@@ -211,6 +213,300 @@ public sealed class AuthorizationStoreTests
 
         Assert.Single(authorizations);
         Assert.Equal(matching.Id, authorizations[0].Id);
+    }
+
+    [Fact]
+    public async Task FindAsync_BySubjectAndClient_ReturnsMatching()
+    {
+        var subject = TestEntities.NewId("subject");
+        var applicationId = TestEntities.NewId("app");
+        var matching = TestEntities.CreateAuthorization(subject: subject, applicationId: applicationId);
+        var nonMatching = TestEntities.CreateAuthorization(subject: subject);
+        await _store.CreateAsync(matching, CancellationToken.None);
+        await _store.CreateAsync(nonMatching, CancellationToken.None);
+
+        var authorizations = await _store.FindAsync(subject, applicationId, CancellationToken.None).ToListAsync();
+
+        Assert.Single(authorizations);
+        Assert.Equal(matching.Id, authorizations[0].Id);
+    }
+
+    [Fact]
+    public async Task FindAsync_BySubjectAndStatusAndType_ReturnsMatching()
+    {
+        var subject = TestEntities.NewId("subject");
+        var matching = TestEntities.CreateAuthorization(subject: subject);
+        matching.Type = OpenIddictConstants.AuthorizationTypes.Permanent;
+        var nonMatching = TestEntities.CreateAuthorization(subject: subject);
+        nonMatching.Type = "ad-hoc";
+        await _store.CreateAsync(matching, CancellationToken.None);
+        await _store.CreateAsync(nonMatching, CancellationToken.None);
+
+        var authorizations = await _store.FindAsync(subject, client: null, OpenIddictConstants.Statuses.Valid, OpenIddictConstants.AuthorizationTypes.Permanent, CancellationToken.None).ToListAsync();
+
+        Assert.Single(authorizations);
+        Assert.Equal(matching.Id, authorizations[0].Id);
+    }
+
+    [Fact]
+    public async Task FindAsync_ByScopes_ReturnsOnlyMatchingAuthorizations()
+    {
+        var subject = TestEntities.NewId("subject");
+        var matching = TestEntities.CreateAuthorization(subject: subject);
+        matching.Scopes = TestEntities.JsonArray("openid", "profile", "email");
+        var nonMatching = TestEntities.CreateAuthorization(subject: subject);
+        nonMatching.Scopes = TestEntities.JsonArray("openid");
+        await _store.CreateAsync(matching, CancellationToken.None);
+        await _store.CreateAsync(nonMatching, CancellationToken.None);
+
+        var authorizations = await _store.FindAsync(
+            subject, client: null, status: null, type: null,
+            scopes: ImmutableArray.Create("openid", "profile", "email"),
+            CancellationToken.None).ToListAsync();
+
+        Assert.Single(authorizations);
+        Assert.Equal(matching.Id, authorizations[0].Id);
+    }
+
+    [Fact]
+    public async Task InstantiateAsync_ReturnsNewInstance()
+    {
+        var authz = await _store.InstantiateAsync(CancellationToken.None);
+        Assert.NotNull(authz);
+        Assert.NotNull(authz.ConcurrencyToken);
+        Assert.NotEmpty(authz.ConcurrencyToken);
+    }
+
+    [Fact]
+    public async Task GetApplicationIdAsync_ReturnsApplicationId()
+    {
+        var authorization = TestEntities.CreateAuthorization();
+        var result = await _store.GetApplicationIdAsync(authorization, CancellationToken.None);
+        Assert.Equal(authorization.ApplicationId, result);
+    }
+
+    [Fact]
+    public async Task GetCreationDateAsync_ReturnsCreationDate()
+    {
+        var authorization = TestEntities.CreateAuthorization();
+        var result = await _store.GetCreationDateAsync(authorization, CancellationToken.None);
+        Assert.Equal(authorization.CreationDate, result);
+    }
+
+    [Fact]
+    public async Task GetIdAsync_ReturnsId()
+    {
+        var authorization = TestEntities.CreateAuthorization();
+        var result = await _store.GetIdAsync(authorization, CancellationToken.None);
+        Assert.Equal(authorization.Id, result);
+    }
+
+    [Fact]
+    public async Task GetPropertiesAsync_ReturnsDeserializedDictionary()
+    {
+        var authorization = TestEntities.CreateAuthorization();
+        var result = await _store.GetPropertiesAsync(authorization, CancellationToken.None);
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task GetScopesAsync_ReturnsDeserializedArray()
+    {
+        var authorization = TestEntities.CreateAuthorization();
+        var result = await _store.GetScopesAsync(authorization, CancellationToken.None);
+        Assert.False(result.IsDefaultOrEmpty);
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_ReturnsStatus()
+    {
+        var authorization = TestEntities.CreateAuthorization();
+        var result = await _store.GetStatusAsync(authorization, CancellationToken.None);
+        Assert.Equal(authorization.Status, result);
+    }
+
+    [Fact]
+    public async Task GetSubjectAsync_ReturnsSubject()
+    {
+        var authorization = TestEntities.CreateAuthorization();
+        var result = await _store.GetSubjectAsync(authorization, CancellationToken.None);
+        Assert.Equal(authorization.Subject, result);
+    }
+
+    [Fact]
+    public async Task GetTypeAsync_ReturnsType()
+    {
+        var authorization = TestEntities.CreateAuthorization();
+        var result = await _store.GetTypeAsync(authorization, CancellationToken.None);
+        Assert.Equal(authorization.Type, result);
+    }
+
+    [Fact]
+    public async Task SetApplicationIdAsync_UpdatesApplicationId()
+    {
+        var authorization = TestEntities.CreateAuthorization();
+        await _store.CreateAsync(authorization, CancellationToken.None);
+
+        var newAppId = TestEntities.NewId("newapp");
+        await _store.SetApplicationIdAsync(authorization, newAppId, CancellationToken.None);
+        await _store.UpdateAsync(authorization, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(authorization.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        Assert.Equal(newAppId, stored.ApplicationId);
+    }
+
+    [Fact]
+    public async Task SetCreationDateAsync_UpdatesCreationDate()
+    {
+        var authorization = TestEntities.CreateAuthorization();
+        await _store.CreateAsync(authorization, CancellationToken.None);
+
+        var newDate = DateTimeOffset.UtcNow.AddDays(-10);
+        await _store.SetCreationDateAsync(authorization, newDate, CancellationToken.None);
+        await _store.UpdateAsync(authorization, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(authorization.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        Assert.Equal(newDate, stored.CreationDate);
+    }
+
+    [Fact]
+    public async Task SetPropertiesAsync_UpdatesProperties()
+    {
+        var authorization = TestEntities.CreateAuthorization();
+        await _store.CreateAsync(authorization, CancellationToken.None);
+
+        using var doc = JsonDocument.Parse("{\"NewProp\":\"NewVal\"}");
+        var properties = ImmutableDictionary.CreateRange(new[] { KeyValuePair.Create("NewProp", doc.RootElement) });
+        await _store.SetPropertiesAsync(authorization, properties, CancellationToken.None);
+        await _store.UpdateAsync(authorization, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(authorization.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        var result = await _store.GetPropertiesAsync(stored, CancellationToken.None);
+        Assert.True(result.ContainsKey("NewProp"));
+    }
+
+    [Fact]
+    public async Task SetScopesAsync_UpdatesScopes()
+    {
+        var authorization = TestEntities.CreateAuthorization();
+        await _store.CreateAsync(authorization, CancellationToken.None);
+
+        var newScopes = ImmutableArray.Create("openid", "email", "custom_scope");
+        await _store.SetScopesAsync(authorization, newScopes, CancellationToken.None);
+        await _store.UpdateAsync(authorization, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(authorization.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        var result = await _store.GetScopesAsync(stored, CancellationToken.None);
+        Assert.Equal(newScopes, result);
+    }
+
+    [Fact]
+    public async Task SetStatusAsync_UpdatesStatus()
+    {
+        var authorization = TestEntities.CreateAuthorization();
+        await _store.CreateAsync(authorization, CancellationToken.None);
+
+        await _store.SetStatusAsync(authorization, OpenIddictConstants.Statuses.Revoked, CancellationToken.None);
+        await _store.UpdateAsync(authorization, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(authorization.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        Assert.Equal(OpenIddictConstants.Statuses.Revoked, stored.Status);
+    }
+
+    [Fact]
+    public async Task SetSubjectAsync_UpdatesSubject()
+    {
+        var authorization = TestEntities.CreateAuthorization();
+        await _store.CreateAsync(authorization, CancellationToken.None);
+
+        var newSubject = TestEntities.NewId("newsubject");
+        await _store.SetSubjectAsync(authorization, newSubject, CancellationToken.None);
+        await _store.UpdateAsync(authorization, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(authorization.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        Assert.Equal(newSubject, stored.Subject);
+    }
+
+    [Fact]
+    public async Task SetTypeAsync_UpdatesType()
+    {
+        var authorization = TestEntities.CreateAuthorization();
+        await _store.CreateAsync(authorization, CancellationToken.None);
+
+        await _store.SetTypeAsync(authorization, "ad-hoc", CancellationToken.None);
+        await _store.UpdateAsync(authorization, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(authorization.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        Assert.Equal("ad-hoc", stored.Type);
+    }
+
+    [Fact]
+    public async Task PruneAsync_RemovesPrunableAuthorizations()
+    {
+        var authorization = TestEntities.CreateAuthorization();
+        authorization.Status = OpenIddictConstants.Statuses.Inactive;
+        authorization.CreationDate = DateTimeOffset.UtcNow.AddDays(-30);
+        await _store.CreateAsync(authorization, CancellationToken.None);
+
+        var pruned = await _store.PruneAsync(DateTimeOffset.UtcNow, CancellationToken.None);
+
+        Assert.Equal(1, pruned);
+        var stored = await _store.FindByIdAsync(authorization.Id, CancellationToken.None);
+        Assert.Null(stored);
+    }
+
+    [Fact]
+    public async Task CountAsync_IncludesCreatedAuthorizations()
+    {
+        var before = await _store.CountAsync(CancellationToken.None);
+        await _store.CreateAsync(TestEntities.CreateAuthorization(), CancellationToken.None);
+        await _store.CreateAsync(TestEntities.CreateAuthorization(), CancellationToken.None);
+
+        var after = await _store.CountAsync(CancellationToken.None);
+
+        Assert.Equal(before + 2, after);
+    }
+
+    [Fact]
+    public async Task ListAsync_ReturnsCreatedAuthorizations()
+    {
+        var first = TestEntities.CreateAuthorization();
+        var second = TestEntities.CreateAuthorization();
+        await _store.CreateAsync(first, CancellationToken.None);
+        await _store.CreateAsync(second, CancellationToken.None);
+
+        var authorizations = await _store.ListAsync(count: null, offset: null, CancellationToken.None).ToListAsync();
+
+        Assert.Contains(authorizations, a => a.Id == first.Id);
+        Assert.Contains(authorizations, a => a.Id == second.Id);
+    }
+
+    [Fact]
+    public async Task CountAsync_WithIQueryable_ThrowsNotSupportedException()
+    {
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => _store.CountAsync<OpenIddictDynamoDbAuthorization>(q => q, CancellationToken.None).AsTask());
+    }
+
+    [Fact]
+    public async Task GetAsync_ThrowsNotSupportedException()
+    {
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => _store.GetAsync<object, string>((q, s) => q.Select(_ => _.Id), "state", CancellationToken.None).AsTask());
+    }
+
+    [Fact]
+    public async Task ListAsync_WithIQueryable_ThrowsNotSupportedException()
+    {
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => _store.ListAsync<object, string>((q, s) => q.Select(_ => _.Id), "state", CancellationToken.None).ToListAsync());
     }
 
 }

--- a/src/OpenIddict.DynamoDb.Tests/Stores/AuthorizationStoreTests.cs
+++ b/src/OpenIddict.DynamoDb.Tests/Stores/AuthorizationStoreTests.cs
@@ -401,7 +401,7 @@ public sealed class AuthorizationStoreTests
         var stored = await _store.FindByIdAsync(authorization.Id, CancellationToken.None);
         Assert.NotNull(stored);
         var result = await _store.GetScopesAsync(stored, CancellationToken.None);
-        Assert.Equal(newScopes, result);
+        Assert.True(newScopes.SequenceEqual(result));
     }
 
     [Fact]

--- a/src/OpenIddict.DynamoDb.Tests/Stores/AuthorizationStoreTests.cs
+++ b/src/OpenIddict.DynamoDb.Tests/Stores/AuthorizationStoreTests.cs
@@ -1,0 +1,216 @@
+using Amazon.DynamoDBv2.Model;
+using OpenIddict.Abstractions;
+using OpenIddict.DynamoDb.Models;
+using OpenIddict.DynamoDb.Tests.Fixtures;
+using OpenIddict.DynamoDb.Tests.Helpers;
+
+namespace OpenIddict.DynamoDb.Tests.Stores;
+
+[Collection(DynamoDbCollection.Name)]
+public sealed class AuthorizationStoreTests
+{
+    private readonly OpenIddictDynamoDbAuthorizationStore<OpenIddictDynamoDbAuthorization> _store;
+
+    public AuthorizationStoreTests(DynamoDbFixture fixture)
+    {
+        _store = new OpenIddictDynamoDbAuthorizationStore<OpenIddictDynamoDbAuthorization>(fixture.Client, fixture.Options);
+    }
+
+    [Fact]
+    public async Task CreateAsync_StoresAuthorization()
+    {
+        var authorization = TestEntities.CreateAuthorization();
+
+        await _store.CreateAsync(authorization, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(authorization.Id, CancellationToken.None);
+
+        Assert.NotNull(stored);
+        Assert.Equal(authorization.Subject, stored.Subject);
+        Assert.Equal(authorization.ApplicationId, stored.ApplicationId);
+        Assert.Equal(authorization.Scopes, stored.Scopes);
+    }
+
+    [Fact]
+    public async Task FindByIdAsync_ReturnsAuthorization()
+    {
+        var authorization = TestEntities.CreateAuthorization();
+        await _store.CreateAsync(authorization, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(authorization.Id, CancellationToken.None);
+
+        Assert.NotNull(stored);
+        Assert.Equal(authorization.Id, stored.Id);
+    }
+
+    [Fact]
+    public async Task FindBySubjectAsync_ReturnsAuthorizationsForSubject()
+    {
+        var subject = TestEntities.NewId("subject");
+        var authorization = TestEntities.CreateAuthorization(subject: subject);
+        await _store.CreateAsync(authorization, CancellationToken.None);
+
+        var authorizations = await _store.FindBySubjectAsync(subject, CancellationToken.None).ToListAsync();
+
+        Assert.Contains(authorizations, item => item.Id == authorization.Id);
+    }
+
+    [Fact]
+    public async Task FindByApplicationIdAsync_ReturnsAuthorizationsForApplication()
+    {
+        var applicationId = TestEntities.NewId("app");
+        var authorization = TestEntities.CreateAuthorization(applicationId: applicationId);
+        await _store.CreateAsync(authorization, CancellationToken.None);
+
+        var authorizations = await _store.FindByApplicationIdAsync(applicationId, CancellationToken.None).ToListAsync();
+
+        Assert.Contains(authorizations, item => item.Id == authorization.Id);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_PersistsStatus()
+    {
+        var authorization = TestEntities.CreateAuthorization();
+        await _store.CreateAsync(authorization, CancellationToken.None);
+
+        authorization.Status = OpenIddictConstants.Statuses.Inactive;
+        await _store.UpdateAsync(authorization, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(authorization.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        Assert.Equal(OpenIddictConstants.Statuses.Inactive, stored.Status);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RemovesAuthorization()
+    {
+        var authorization = TestEntities.CreateAuthorization();
+        await _store.CreateAsync(authorization, CancellationToken.None);
+
+        await _store.DeleteAsync(authorization, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(authorization.Id, CancellationToken.None);
+        Assert.Null(stored);
+    }
+
+    [Fact]
+    public async Task RevokeAsync_RevokesMatchingAuthorization()
+    {
+        var authorization = TestEntities.CreateAuthorization();
+        await _store.CreateAsync(authorization, CancellationToken.None);
+
+        var count = await _store.RevokeAsync(authorization.Subject, authorization.ApplicationId, authorization.Status, authorization.Type, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(authorization.Id, CancellationToken.None);
+        Assert.Equal(1, count);
+        Assert.NotNull(stored);
+        Assert.Equal(OpenIddictConstants.Statuses.Revoked, stored.Status);
+    }
+
+    [Fact]
+    public async Task RevokeByApplicationIdAsync_RevokesAuthorizationsForApplication()
+    {
+        var applicationId = TestEntities.NewId("app");
+        var authorization = TestEntities.CreateAuthorization(applicationId: applicationId);
+        await _store.CreateAsync(authorization, CancellationToken.None);
+
+        var count = await _store.RevokeByApplicationIdAsync(applicationId, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(authorization.Id, CancellationToken.None);
+        Assert.Equal(1, count);
+        Assert.NotNull(stored);
+        Assert.Equal(OpenIddictConstants.Statuses.Revoked, stored.Status);
+    }
+
+    [Fact]
+    public async Task RevokeBySubjectAsync_RevokesAuthorizationsForSubject()
+    {
+        var subject = TestEntities.NewId("subject");
+        var authorization = TestEntities.CreateAuthorization(subject: subject);
+        await _store.CreateAsync(authorization, CancellationToken.None);
+
+        var count = await _store.RevokeBySubjectAsync(subject, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(authorization.Id, CancellationToken.None);
+        Assert.Equal(1, count);
+        Assert.NotNull(stored);
+        Assert.Equal(OpenIddictConstants.Statuses.Revoked, stored.Status);
+    }
+    [Fact]
+    public async Task FindByIdAsync_NotFound_ReturnsNull()
+    {
+        var result = await _store.FindByIdAsync("nonexistent-id", CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task FindBySubjectAsync_NotFound_ReturnsEmpty()
+    {
+        var authorizations = await _store.FindBySubjectAsync("nonexistent-subject", CancellationToken.None).ToListAsync();
+
+        Assert.Empty(authorizations);
+    }
+
+    [Fact]
+    public async Task FindByApplicationIdAsync_NotFound_ReturnsEmpty()
+    {
+        var authorizations = await _store.FindByApplicationIdAsync("nonexistent-application", CancellationToken.None).ToListAsync();
+
+        Assert.Empty(authorizations);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_StaleConcurrencyToken_Throws()
+    {
+        var authorization = TestEntities.CreateAuthorization();
+        await _store.CreateAsync(authorization, CancellationToken.None);
+
+        var originalToken = authorization.ConcurrencyToken;
+
+        authorization.Status = OpenIddictConstants.Statuses.Inactive;
+        await _store.UpdateAsync(authorization, CancellationToken.None);
+
+        authorization.ConcurrencyToken = originalToken;
+        authorization.Status = OpenIddictConstants.Statuses.Revoked;
+        var exception = await Assert.ThrowsAsync<OpenIddictExceptions.ConcurrencyException>(
+            () => _store.UpdateAsync(authorization, CancellationToken.None).AsTask());
+
+        Assert.IsType<ConditionalCheckFailedException>(exception.InnerException);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_StaleConcurrencyToken_Throws()
+    {
+        var authorization = TestEntities.CreateAuthorization();
+        await _store.CreateAsync(authorization, CancellationToken.None);
+
+        var originalToken = authorization.ConcurrencyToken;
+
+        authorization.Status = OpenIddictConstants.Statuses.Inactive;
+        await _store.UpdateAsync(authorization, CancellationToken.None);
+
+        authorization.ConcurrencyToken = originalToken;
+        var exception = await Assert.ThrowsAsync<OpenIddictExceptions.ConcurrencyException>(
+            () => _store.DeleteAsync(authorization, CancellationToken.None).AsTask());
+
+        Assert.IsType<ConditionalCheckFailedException>(exception.InnerException);
+    }
+
+    [Fact]
+    public async Task FindAsync_BySubjectAndStatus_ReturnsMatching()
+    {
+        var subject = TestEntities.NewId("subject");
+        var matching = TestEntities.CreateAuthorization(subject: subject);
+        var nonMatching = TestEntities.CreateAuthorization(subject: subject);
+        nonMatching.Status = OpenIddictConstants.Statuses.Inactive;
+        await _store.CreateAsync(matching, CancellationToken.None);
+        await _store.CreateAsync(nonMatching, CancellationToken.None);
+
+        var authorizations = await _store.FindAsync(subject, client: null, OpenIddictConstants.Statuses.Valid, CancellationToken.None).ToListAsync();
+
+        Assert.Single(authorizations);
+        Assert.Equal(matching.Id, authorizations[0].Id);
+    }
+
+}

--- a/src/OpenIddict.DynamoDb.Tests/Stores/ScopeStoreTests.cs
+++ b/src/OpenIddict.DynamoDb.Tests/Stores/ScopeStoreTests.cs
@@ -1,3 +1,6 @@
+using System.Collections.Immutable;
+using System.Globalization;
+using System.Text.Json;
 using Amazon.DynamoDBv2.Model;
 using OpenIddict.Abstractions;
 using OpenIddict.DynamoDb.Models;
@@ -165,6 +168,300 @@ public sealed class ScopeStoreTests
             () => _store.DeleteAsync(scope, CancellationToken.None).AsTask());
 
         AssertDynamoDbConcurrencyFailure(exception);
+    }
+
+
+    [Fact]
+    public async Task FindByNamesAsync_ReturnsMatchingScopes()
+    {
+        var name1 = TestEntities.NewId("scope-name");
+        var name2 = TestEntities.NewId("scope-name");
+        var scope1 = TestEntities.CreateScope(name: name1);
+        var scope2 = TestEntities.CreateScope(name: name2);
+        var scope3 = TestEntities.CreateScope();
+        await _store.CreateAsync(scope1, CancellationToken.None);
+        await _store.CreateAsync(scope2, CancellationToken.None);
+        await _store.CreateAsync(scope3, CancellationToken.None);
+
+        var results = await _store.FindByNamesAsync(ImmutableArray.Create(name1, name2), CancellationToken.None).ToListAsync();
+
+        Assert.Equal(2, results.Count);
+        Assert.Contains(results, s => s.Id == scope1.Id);
+        Assert.Contains(results, s => s.Id == scope2.Id);
+    }
+
+    [Fact]
+    public async Task FindByResourceAsync_ReturnsMatchingScopes()
+    {
+        var resource = $"resource-{Guid.NewGuid():N}";
+        var scope = TestEntities.CreateScope();
+        scope.Resources = TestEntities.JsonArray(resource);
+        await _store.CreateAsync(scope, CancellationToken.None);
+
+        var results = await _store.FindByResourceAsync(resource, CancellationToken.None).ToListAsync();
+
+        Assert.Single(results);
+        Assert.Equal(scope.Id, results[0].Id);
+    }
+
+    [Fact]
+    public async Task InstantiateAsync_ReturnsNewInstance()
+    {
+        var scope = await _store.InstantiateAsync(CancellationToken.None);
+        Assert.NotNull(scope);
+        Assert.NotNull(scope.ConcurrencyToken);
+        Assert.NotEmpty(scope.ConcurrencyToken);
+    }
+
+    [Fact]
+    public async Task GetDescriptionAsync_ReturnsDescription()
+    {
+        var scope = TestEntities.CreateScope();
+        var result = await _store.GetDescriptionAsync(scope, CancellationToken.None);
+        Assert.Equal(scope.Description, result);
+    }
+
+    [Fact]
+    public async Task GetDescriptionsAsync_ReturnsDeserializedDictionary()
+    {
+        var scope = TestEntities.CreateScope();
+        var result = await _store.GetDescriptionsAsync(scope, CancellationToken.None);
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task GetDisplayNameAsync_ReturnsDisplayName()
+    {
+        var scope = TestEntities.CreateScope();
+        var result = await _store.GetDisplayNameAsync(scope, CancellationToken.None);
+        Assert.Equal(scope.DisplayName, result);
+    }
+
+    [Fact]
+    public async Task GetDisplayNamesAsync_ReturnsDeserializedDictionary()
+    {
+        var scope = TestEntities.CreateScope();
+        var result = await _store.GetDisplayNamesAsync(scope, CancellationToken.None);
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task GetIdAsync_ReturnsId()
+    {
+        var scope = TestEntities.CreateScope();
+        var result = await _store.GetIdAsync(scope, CancellationToken.None);
+        Assert.Equal(scope.Id, result);
+    }
+
+    [Fact]
+    public async Task GetNameAsync_ReturnsName()
+    {
+        var scope = TestEntities.CreateScope();
+        var result = await _store.GetNameAsync(scope, CancellationToken.None);
+        Assert.Equal(scope.Name, result);
+    }
+
+    [Fact]
+    public async Task GetPropertiesAsync_ReturnsDeserializedDictionary()
+    {
+        var scope = TestEntities.CreateScope();
+        var result = await _store.GetPropertiesAsync(scope, CancellationToken.None);
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task GetResourcesAsync_ReturnsDeserializedArray()
+    {
+        var scope = TestEntities.CreateScope();
+        var result = await _store.GetResourcesAsync(scope, CancellationToken.None);
+        Assert.False(result.IsDefaultOrEmpty);
+    }
+
+    [Fact]
+    public async Task SetDescriptionAsync_UpdatesDescription()
+    {
+        var scope = TestEntities.CreateScope();
+        await _store.CreateAsync(scope, CancellationToken.None);
+
+        await _store.SetDescriptionAsync(scope, "New description", CancellationToken.None);
+        await _store.UpdateAsync(scope, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(scope.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        Assert.Equal("New description", stored.Description);
+    }
+
+    [Fact]
+    public async Task SetDescriptionsAsync_UpdatesDescriptions()
+    {
+        var scope = TestEntities.CreateScope();
+        await _store.CreateAsync(scope, CancellationToken.None);
+
+        var descriptions = ImmutableDictionary.CreateBuilder<CultureInfo, string>();
+        descriptions[CultureInfo.GetCultureInfo("en")] = "English Description";
+        await _store.SetDescriptionsAsync(scope, descriptions.ToImmutable(), CancellationToken.None);
+        await _store.UpdateAsync(scope, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(scope.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        var result = await _store.GetDescriptionsAsync(stored, CancellationToken.None);
+        Assert.Equal("English Description", result[CultureInfo.GetCultureInfo("en")]);
+    }
+
+    [Fact]
+    public async Task SetDisplayNameAsync_UpdatesDisplayName()
+    {
+        var scope = TestEntities.CreateScope();
+        await _store.CreateAsync(scope, CancellationToken.None);
+
+        await _store.SetDisplayNameAsync(scope, "New Display Name", CancellationToken.None);
+        await _store.UpdateAsync(scope, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(scope.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        Assert.Equal("New Display Name", stored.DisplayName);
+    }
+
+    [Fact]
+    public async Task SetDisplayNamesAsync_UpdatesDisplayNames()
+    {
+        var scope = TestEntities.CreateScope();
+        await _store.CreateAsync(scope, CancellationToken.None);
+
+        var names = ImmutableDictionary.CreateBuilder<CultureInfo, string>();
+        names[CultureInfo.GetCultureInfo("en")] = "English Name";
+        names[CultureInfo.GetCultureInfo("de")] = "German Name";
+        await _store.SetDisplayNamesAsync(scope, names.ToImmutable(), CancellationToken.None);
+        await _store.UpdateAsync(scope, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(scope.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        var result = await _store.GetDisplayNamesAsync(stored, CancellationToken.None);
+        Assert.Equal("English Name", result[CultureInfo.GetCultureInfo("en")]);
+        Assert.Equal("German Name", result[CultureInfo.GetCultureInfo("de")]);
+    }
+
+    [Fact]
+    public async Task SetNameAsync_UpdatesName()
+    {
+        var scope = TestEntities.CreateScope();
+        await _store.CreateAsync(scope, CancellationToken.None);
+
+        var newName = TestEntities.NewId("new-scope-name");
+        await _store.SetNameAsync(scope, newName, CancellationToken.None);
+        await _store.UpdateAsync(scope, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(scope.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        Assert.Equal(newName, stored.Name);
+    }
+
+    [Fact]
+    public async Task SetPropertiesAsync_UpdatesProperties()
+    {
+        var scope = TestEntities.CreateScope();
+        await _store.CreateAsync(scope, CancellationToken.None);
+
+        using var doc = JsonDocument.Parse("{\"NewProp\":\"NewVal\"}");
+        var properties = ImmutableDictionary.CreateRange(new[] { KeyValuePair.Create("NewProp", doc.RootElement) });
+        await _store.SetPropertiesAsync(scope, properties, CancellationToken.None);
+        await _store.UpdateAsync(scope, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(scope.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        var result = await _store.GetPropertiesAsync(stored, CancellationToken.None);
+        Assert.True(result.ContainsKey("NewProp"));
+    }
+
+    [Fact]
+    public async Task SetResourcesAsync_UpdatesResources()
+    {
+        var scope = TestEntities.CreateScope();
+        await _store.CreateAsync(scope, CancellationToken.None);
+
+        var newResources = ImmutableArray.Create($"resource-{Guid.NewGuid():N}", $"resource-{Guid.NewGuid():N}");
+        await _store.SetResourcesAsync(scope, newResources, CancellationToken.None);
+        await _store.UpdateAsync(scope, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(scope.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        var result = await _store.GetResourcesAsync(stored, CancellationToken.None);
+        Assert.Equal(newResources, result);
+    }
+
+    [Fact]
+    public async Task CountAsync_WithIQueryable_ThrowsNotSupportedException()
+    {
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => _store.CountAsync<OpenIddictDynamoDbScope>(q => q, CancellationToken.None).AsTask());
+    }
+
+    [Fact]
+    public async Task GetAsync_ThrowsNotSupportedException()
+    {
+        var scope = TestEntities.CreateScope();
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => _store.GetAsync<object, string>((q, s) => q.Select(_ => _.Id), "state", CancellationToken.None).AsTask());
+    }
+
+    [Fact]
+    public async Task ListAsync_WithIQueryable_ThrowsNotSupportedException()
+    {
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => _store.ListAsync<object, string>((q, s) => q.Select(_ => _.Id), "state", CancellationToken.None).ToListAsync());
+    }
+
+    [Fact]
+    public async Task FindByNamesAsync_EmptyArray_ReturnsEmpty()
+    {
+        var scope = TestEntities.CreateScope();
+        await _store.CreateAsync(scope, CancellationToken.None);
+
+        var results = await _store.FindByNamesAsync(ImmutableArray<string>.Empty, CancellationToken.None).ToListAsync();
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task FindByResourceAsync_NotFound_ReturnsEmpty()
+    {
+        var results = await _store.FindByResourceAsync("nonexistent-resource", CancellationToken.None).ToListAsync();
+
+        Assert.Empty(results);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_RenamingScope_OldNameLookupStopsResolving()
+    {
+        var originalName = TestEntities.NewId("scope-name");
+        var scope = TestEntities.CreateScope(name: originalName);
+        await _store.CreateAsync(scope, CancellationToken.None);
+
+        var newName = TestEntities.NewId("renamed-scope");
+        await _store.SetNameAsync(scope, newName, CancellationToken.None);
+        await _store.UpdateAsync(scope, CancellationToken.None);
+
+        var byOldName = await _store.FindByNameAsync(originalName, CancellationToken.None);
+        Assert.Null(byOldName);
+
+        var byNewName = await _store.FindByNameAsync(newName, CancellationToken.None);
+        Assert.NotNull(byNewName);
+        Assert.Equal(scope.Id, byNewName.Id);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_RemovingResource_ResourceLookupStopsResolving()
+    {
+        var resource = $"resource-{Guid.NewGuid():N}";
+        var scope = TestEntities.CreateScope();
+        scope.Resources = TestEntities.JsonArray(resource);
+        await _store.CreateAsync(scope, CancellationToken.None);
+
+        await _store.SetResourcesAsync(scope, ImmutableArray<string>.Empty, CancellationToken.None);
+        await _store.UpdateAsync(scope, CancellationToken.None);
+
+        var byResource = await _store.FindByResourceAsync(resource, CancellationToken.None).ToListAsync();
+        Assert.Empty(byResource);
     }
 
     private async Task<OpenIddictDynamoDbScopeStore<OpenIddictDynamoDbScope>> CreateEmptyStoreAsync()

--- a/src/OpenIddict.DynamoDb.Tests/Stores/ScopeStoreTests.cs
+++ b/src/OpenIddict.DynamoDb.Tests/Stores/ScopeStoreTests.cs
@@ -386,7 +386,7 @@ public sealed class ScopeStoreTests
         var stored = await _store.FindByIdAsync(scope.Id, CancellationToken.None);
         Assert.NotNull(stored);
         var result = await _store.GetResourcesAsync(stored, CancellationToken.None);
-        Assert.Equal(newResources, result);
+        Assert.True(newResources.SequenceEqual(result));
     }
 
     [Fact]

--- a/src/OpenIddict.DynamoDb.Tests/Stores/ScopeStoreTests.cs
+++ b/src/OpenIddict.DynamoDb.Tests/Stores/ScopeStoreTests.cs
@@ -1,0 +1,188 @@
+using Amazon.DynamoDBv2.Model;
+using OpenIddict.Abstractions;
+using OpenIddict.DynamoDb.Models;
+using OpenIddict.DynamoDb.Tests.Fixtures;
+using OpenIddict.DynamoDb.Tests.Helpers;
+
+namespace OpenIddict.DynamoDb.Tests.Stores;
+
+[Collection(DynamoDbCollection.Name)]
+public sealed class ScopeStoreTests
+{
+    private readonly OpenIddictDynamoDbScopeStore<OpenIddictDynamoDbScope> _store;
+    private readonly DynamoDbFixture _fixture;
+
+    public ScopeStoreTests(DynamoDbFixture fixture)
+    {
+        _store = new OpenIddictDynamoDbScopeStore<OpenIddictDynamoDbScope>(fixture.Client, fixture.Options);
+        _fixture = fixture;
+    }
+
+    [Fact]
+    public async Task CreateAsync_StoresScope()
+    {
+        var scope = TestEntities.CreateScope();
+
+        await _store.CreateAsync(scope, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(scope.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        Assert.Equal(scope.Name, stored.Name);
+        Assert.Equal(scope.Resources, stored.Resources);
+    }
+
+    [Fact]
+    public async Task FindByIdAsync_ReturnsScope()
+    {
+        var scope = TestEntities.CreateScope();
+        await _store.CreateAsync(scope, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(scope.Id, CancellationToken.None);
+
+        Assert.NotNull(stored);
+        Assert.Equal(scope.Id, stored.Id);
+    }
+
+    [Fact]
+    public async Task FindByNameAsync_ReturnsScope()
+    {
+        var scope = TestEntities.CreateScope(name: TestEntities.NewId("scope-name"));
+        await _store.CreateAsync(scope, CancellationToken.None);
+
+        var stored = await _store.FindByNameAsync(scope.Name!, CancellationToken.None);
+
+        Assert.NotNull(stored);
+        Assert.Equal(scope.Id, stored.Id);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_PersistsDisplayName()
+    {
+        var scope = TestEntities.CreateScope();
+        await _store.CreateAsync(scope, CancellationToken.None);
+
+        scope.DisplayName = "Updated scope";
+        await _store.UpdateAsync(scope, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(scope.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        Assert.Equal("Updated scope", stored.DisplayName);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RemovesScope()
+    {
+        var scope = TestEntities.CreateScope();
+        await _store.CreateAsync(scope, CancellationToken.None);
+
+        await _store.DeleteAsync(scope, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(scope.Id, CancellationToken.None);
+        Assert.Null(stored);
+    }
+
+    [Fact]
+    public async Task ListAsync_ReturnsCreatedScopes()
+    {
+        var first = TestEntities.CreateScope();
+        var second = TestEntities.CreateScope();
+        await _store.CreateAsync(first, CancellationToken.None);
+        await _store.CreateAsync(second, CancellationToken.None);
+
+        var scopes = await _store.ListAsync(count: null, offset: null, CancellationToken.None).ToListAsync();
+
+        Assert.Contains(scopes, scope => scope.Id == first.Id);
+        Assert.Contains(scopes, scope => scope.Id == second.Id);
+    }
+    [Fact]
+    public async Task FindByIdAsync_NotFound_ReturnsNull()
+    {
+        var result = await _store.FindByIdAsync("nonexistent-id", CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task FindByNameAsync_NotFound_ReturnsNull()
+    {
+        var result = await _store.FindByNameAsync("nonexistent-name", CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task CountAsync_EmptyTable_ReturnsZero()
+    {
+        var store = await CreateEmptyStoreAsync();
+
+        var count = await store.CountAsync(CancellationToken.None);
+
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public async Task ListAsync_EmptyTable_ReturnsEmpty()
+    {
+        var store = await CreateEmptyStoreAsync();
+
+        var scopes = await store.ListAsync(count: null, offset: null, CancellationToken.None).ToListAsync();
+
+        Assert.Empty(scopes);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_StaleConcurrencyToken_Throws()
+    {
+        var scope = TestEntities.CreateScope();
+        await _store.CreateAsync(scope, CancellationToken.None);
+
+        var originalToken = scope.ConcurrencyToken;
+
+        scope.DisplayName = "Updated scope";
+        await _store.UpdateAsync(scope, CancellationToken.None);
+
+        scope.ConcurrencyToken = originalToken;
+        scope.DisplayName = "Should fail";
+        var exception = await Assert.ThrowsAsync<OpenIddictExceptions.ConcurrencyException>(
+            () => _store.UpdateAsync(scope, CancellationToken.None).AsTask());
+
+        AssertDynamoDbConcurrencyFailure(exception);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_StaleConcurrencyToken_Throws()
+    {
+        var scope = TestEntities.CreateScope();
+        await _store.CreateAsync(scope, CancellationToken.None);
+
+        var originalToken = scope.ConcurrencyToken;
+
+        scope.DisplayName = "Updated scope";
+        await _store.UpdateAsync(scope, CancellationToken.None);
+
+        scope.ConcurrencyToken = originalToken;
+        var exception = await Assert.ThrowsAsync<OpenIddictExceptions.ConcurrencyException>(
+            () => _store.DeleteAsync(scope, CancellationToken.None).AsTask());
+
+        AssertDynamoDbConcurrencyFailure(exception);
+    }
+
+    private async Task<OpenIddictDynamoDbScopeStore<OpenIddictDynamoDbScope>> CreateEmptyStoreAsync()
+    {
+        var options = new OpenIddictDynamoDbOptions
+        {
+            ApplicationsTableName = $"{_fixture.Options.ApplicationsTableName}-empty-{Guid.NewGuid():N}",
+            AuthorizationsTableName = $"{_fixture.Options.AuthorizationsTableName}-empty-{Guid.NewGuid():N}",
+            ScopesTableName = $"{_fixture.Options.ScopesTableName}-empty-{Guid.NewGuid():N}",
+            TokensTableName = $"{_fixture.Options.TokensTableName}-empty-{Guid.NewGuid():N}"
+        };
+
+        await OpenIddictDynamoDbTableCreator.CreateTablesAsync(_fixture.Client, options, CancellationToken.None);
+
+        return new OpenIddictDynamoDbScopeStore<OpenIddictDynamoDbScope>(_fixture.Client, options);
+    }
+
+    private static void AssertDynamoDbConcurrencyFailure(OpenIddictExceptions.ConcurrencyException exception)
+        => Assert.True(exception.InnerException is ConditionalCheckFailedException or TransactionCanceledException);
+
+}

--- a/src/OpenIddict.DynamoDb.Tests/Stores/TokenStoreTests.cs
+++ b/src/OpenIddict.DynamoDb.Tests/Stores/TokenStoreTests.cs
@@ -1,3 +1,5 @@
+using System.Collections.Immutable;
+using System.Text.Json;
 using Amazon.DynamoDBv2.Model;
 using OpenIddict.Abstractions;
 using OpenIddict.DynamoDb.Models;
@@ -286,7 +288,471 @@ public sealed class TokenStoreTests
         Assert.Equal(matching.Id, tokens[0].Id);
     }
 
+    [Fact]
+    public async Task FindByIdAsync_ExpiredToken_ReturnsNull()
+    {
+        var token = TestEntities.CreateToken();
+        token.ExpirationDate = DateTimeOffset.UtcNow.AddHours(-1);
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        var result = await _store.FindByIdAsync(token.Id, CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task FindByReferenceIdAsync_ExpiredToken_ReturnsNull()
+    {
+        var token = TestEntities.CreateToken(referenceId: TestEntities.NewId("reference"));
+        token.ExpirationDate = DateTimeOffset.UtcNow.AddHours(-1);
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        var result = await _store.FindByReferenceIdAsync(token.ReferenceId!, CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task FindBySubjectAsync_ExpiredToken_ExcludedFromResults()
+    {
+        var subject = TestEntities.NewId("subject");
+        var validToken = TestEntities.CreateToken(subject: subject);
+        var expiredToken = TestEntities.CreateToken(subject: subject);
+        expiredToken.ExpirationDate = DateTimeOffset.UtcNow.AddHours(-1);
+        await _store.CreateAsync(validToken, CancellationToken.None);
+        await _store.CreateAsync(expiredToken, CancellationToken.None);
+
+        var tokens = await _store.FindBySubjectAsync(subject, CancellationToken.None).ToListAsync();
+
+        Assert.Single(tokens);
+        Assert.Equal(validToken.Id, tokens[0].Id);
+    }
+
+    [Fact]
+    public async Task FindByApplicationIdAsync_ExpiredToken_ExcludedFromResults()
+    {
+        var applicationId = TestEntities.NewId("app");
+        var validToken = TestEntities.CreateToken(applicationId: applicationId);
+        var expiredToken = TestEntities.CreateToken(applicationId: applicationId);
+        expiredToken.ExpirationDate = DateTimeOffset.UtcNow.AddHours(-1);
+        await _store.CreateAsync(validToken, CancellationToken.None);
+        await _store.CreateAsync(expiredToken, CancellationToken.None);
+
+        var tokens = await _store.FindByApplicationIdAsync(applicationId, CancellationToken.None).ToListAsync();
+
+        Assert.Single(tokens);
+        Assert.Equal(validToken.Id, tokens[0].Id);
+    }
+
+    [Fact]
+    public async Task FindAsync_ExpiredToken_ExcludedFromResults()
+    {
+        var subject = TestEntities.NewId("subject");
+        var validToken = TestEntities.CreateToken(subject: subject);
+        var expiredToken = TestEntities.CreateToken(subject: subject);
+        expiredToken.ExpirationDate = DateTimeOffset.UtcNow.AddHours(-1);
+        await _store.CreateAsync(validToken, CancellationToken.None);
+        await _store.CreateAsync(expiredToken, CancellationToken.None);
+
+        var tokens = await _store.FindAsync(subject, client: null, CancellationToken.None).ToListAsync();
+
+        Assert.Single(tokens);
+        Assert.Equal(validToken.Id, tokens[0].Id);
+    }
+
+    [Fact]
+    public async Task PruneAsync_RemovesPrunableTokens_AndPhysicallyDeletes()
+    {
+        var token = TestEntities.CreateToken();
+        token.Status = OpenIddictConstants.Statuses.Revoked;
+        token.CreationDate = DateTimeOffset.UtcNow.AddDays(-30);
+        token.ExpirationDate = DateTimeOffset.UtcNow.AddDays(-1);
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        var pruned = await _store.PruneAsync(DateTimeOffset.UtcNow, CancellationToken.None);
+
+        Assert.Equal(1, pruned);
+        var countAfter = await _store.CountAsync(CancellationToken.None);
+        Assert.Equal(0, countAfter);
+    }
+
+    [Fact]
+    public async Task FindByAuthorizationIdAsync_DoesNotFilterExpired()
+    {
+        var authorizationId = TestEntities.NewId("authz");
+        var token = TestEntities.CreateToken(authorizationId: authorizationId);
+        token.ExpirationDate = DateTimeOffset.UtcNow.AddHours(-1);
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        var tokens = await _store.FindByAuthorizationIdAsync(authorizationId, CancellationToken.None).ToListAsync();
+
+        // FindByAuthorizationIdAsync intentionally does NOT filter expired tokens
+        // (unlike FindBySubjectAsync, FindByApplicationIdAsync which do)
+        Assert.Single(tokens);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_RemovingReferenceId_CleansUpLookup()
+    {
+        var referenceId = TestEntities.NewId("ref");
+        var token = TestEntities.CreateToken(referenceId: referenceId);
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        await _store.SetReferenceIdAsync(token, null, CancellationToken.None);
+        await _store.UpdateAsync(token, CancellationToken.None);
+
+        var byOldRef = await _store.FindByReferenceIdAsync(referenceId, CancellationToken.None);
+        Assert.Null(byOldRef);
+    }
+
     private static void AssertDynamoDbConcurrencyFailure(OpenIddictExceptions.ConcurrencyException exception)
         => Assert.True(exception.InnerException is ConditionalCheckFailedException or TransactionCanceledException);
+
+    [Fact]
+    public async Task FindAsync_BySubjectAndStatusAndType_ReturnsMatching()
+    {
+        var subject = TestEntities.NewId("subject");
+        var matching = TestEntities.CreateToken(subject: subject);
+        matching.Type = OpenIddictConstants.TokenTypeHints.AccessToken;
+        var nonMatching = TestEntities.CreateToken(subject: subject);
+        nonMatching.Type = OpenIddictConstants.TokenTypeHints.RefreshToken;
+        await _store.CreateAsync(matching, CancellationToken.None);
+        await _store.CreateAsync(nonMatching, CancellationToken.None);
+
+        var tokens = await _store.FindAsync(subject, client: null, OpenIddictConstants.Statuses.Valid, OpenIddictConstants.TokenTypeHints.AccessToken, CancellationToken.None).ToListAsync();
+
+        Assert.Single(tokens);
+        Assert.Equal(matching.Id, tokens[0].Id);
+    }
+
+    [Fact]
+    public async Task ListAsync_ReturnsCreatedTokens()
+    {
+        var first = TestEntities.CreateToken();
+        var second = TestEntities.CreateToken();
+        await _store.CreateAsync(first, CancellationToken.None);
+        await _store.CreateAsync(second, CancellationToken.None);
+
+        var tokens = await _store.ListAsync(count: null, offset: null, CancellationToken.None).ToListAsync();
+
+        Assert.Contains(tokens, t => t.Id == first.Id);
+        Assert.Contains(tokens, t => t.Id == second.Id);
+    }
+
+    [Fact]
+    public async Task CountAsync_IncludesCreatedTokens()
+    {
+        var before = await _store.CountAsync(CancellationToken.None);
+        await _store.CreateAsync(TestEntities.CreateToken(), CancellationToken.None);
+        await _store.CreateAsync(TestEntities.CreateToken(), CancellationToken.None);
+
+        var after = await _store.CountAsync(CancellationToken.None);
+
+        Assert.Equal(before + 2, after);
+    }
+
+    [Fact]
+    public async Task InstantiateAsync_ReturnsNewInstance()
+    {
+        var token = await _store.InstantiateAsync(CancellationToken.None);
+        Assert.NotNull(token);
+        Assert.NotEmpty(token.ConcurrencyToken);
+    }
+
+    [Fact]
+    public async Task GetApplicationIdAsync_ReturnsApplicationId()
+    {
+        var token = TestEntities.CreateToken();
+        var result = await _store.GetApplicationIdAsync(token, CancellationToken.None);
+        Assert.Equal(token.ApplicationId, result);
+    }
+
+    [Fact]
+    public async Task GetAuthorizationIdAsync_ReturnsAuthorizationId()
+    {
+        var token = TestEntities.CreateToken();
+        var result = await _store.GetAuthorizationIdAsync(token, CancellationToken.None);
+        Assert.Equal(token.AuthorizationId, result);
+    }
+
+    [Fact]
+    public async Task GetCreationDateAsync_ReturnsCreationDate()
+    {
+        var token = TestEntities.CreateToken();
+        var result = await _store.GetCreationDateAsync(token, CancellationToken.None);
+        Assert.Equal(token.CreationDate, result);
+    }
+
+    [Fact]
+    public async Task GetExpirationDateAsync_ReturnsExpirationDate()
+    {
+        var token = TestEntities.CreateToken();
+        var result = await _store.GetExpirationDateAsync(token, CancellationToken.None);
+        Assert.Equal(token.ExpirationDate, result);
+    }
+
+    [Fact]
+    public async Task GetIdAsync_ReturnsId()
+    {
+        var token = TestEntities.CreateToken();
+        var result = await _store.GetIdAsync(token, CancellationToken.None);
+        Assert.Equal(token.Id, result);
+    }
+
+    [Fact]
+    public async Task GetPayloadAsync_ReturnsPayload()
+    {
+        var token = TestEntities.CreateToken();
+        var result = await _store.GetPayloadAsync(token, CancellationToken.None);
+        Assert.Equal(token.Payload, result);
+    }
+
+    [Fact]
+    public async Task GetPropertiesAsync_ReturnsDeserializedDictionary()
+    {
+        var token = TestEntities.CreateToken();
+        var result = await _store.GetPropertiesAsync(token, CancellationToken.None);
+        Assert.NotNull(result);
+    }
+
+    [Fact]
+    public async Task GetRedemptionDateAsync_ReturnsRedemptionDate()
+    {
+        var token = TestEntities.CreateToken();
+        var result = await _store.GetRedemptionDateAsync(token, CancellationToken.None);
+        Assert.Equal(token.RedemptionDate, result);
+    }
+
+    [Fact]
+    public async Task GetReferenceIdAsync_ReturnsReferenceId()
+    {
+        var token = TestEntities.CreateToken();
+        var result = await _store.GetReferenceIdAsync(token, CancellationToken.None);
+        Assert.Equal(token.ReferenceId, result);
+    }
+
+    [Fact]
+    public async Task GetStatusAsync_ReturnsStatus()
+    {
+        var token = TestEntities.CreateToken();
+        var result = await _store.GetStatusAsync(token, CancellationToken.None);
+        Assert.Equal(token.Status, result);
+    }
+
+    [Fact]
+    public async Task GetSubjectAsync_ReturnsSubject()
+    {
+        var token = TestEntities.CreateToken();
+        var result = await _store.GetSubjectAsync(token, CancellationToken.None);
+        Assert.Equal(token.Subject, result);
+    }
+
+    [Fact]
+    public async Task GetTypeAsync_ReturnsType()
+    {
+        var token = TestEntities.CreateToken();
+        var result = await _store.GetTypeAsync(token, CancellationToken.None);
+        Assert.Equal(token.Type, result);
+    }
+
+    [Fact]
+    public async Task SetApplicationIdAsync_UpdatesApplicationId()
+    {
+        var token = TestEntities.CreateToken();
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        var newAppId = TestEntities.NewId("newapp");
+        await _store.SetApplicationIdAsync(token, newAppId, CancellationToken.None);
+        await _store.UpdateAsync(token, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(token.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        Assert.Equal(newAppId, stored.ApplicationId);
+    }
+
+    [Fact]
+    public async Task SetAuthorizationIdAsync_UpdatesAuthorizationId()
+    {
+        var token = TestEntities.CreateToken();
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        var newAuthzId = TestEntities.NewId("newauthz");
+        await _store.SetAuthorizationIdAsync(token, newAuthzId, CancellationToken.None);
+        await _store.UpdateAsync(token, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(token.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        Assert.Equal(newAuthzId, stored.AuthorizationId);
+    }
+
+    [Fact]
+    public async Task SetCreationDateAsync_UpdatesCreationDate()
+    {
+        var token = TestEntities.CreateToken();
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        var newDate = DateTimeOffset.UtcNow.AddDays(-5);
+        await _store.SetCreationDateAsync(token, newDate, CancellationToken.None);
+        await _store.UpdateAsync(token, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(token.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        Assert.Equal(newDate, stored.CreationDate);
+    }
+
+    [Fact]
+    public async Task SetExpirationDateAsync_UpdatesExpirationDate()
+    {
+        var token = TestEntities.CreateToken();
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        var newDate = DateTimeOffset.UtcNow.AddDays(7);
+        await _store.SetExpirationDateAsync(token, newDate, CancellationToken.None);
+        await _store.UpdateAsync(token, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(token.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        Assert.Equal(newDate, stored.ExpirationDate);
+    }
+
+    [Fact]
+    public async Task SetPayloadAsync_UpdatesPayload()
+    {
+        var token = TestEntities.CreateToken();
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        await _store.SetPayloadAsync(token, "new-payload-data", CancellationToken.None);
+        await _store.UpdateAsync(token, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(token.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        Assert.Equal("new-payload-data", stored.Payload);
+    }
+
+    [Fact]
+    public async Task SetPropertiesAsync_UpdatesProperties()
+    {
+        var token = TestEntities.CreateToken();
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        using var doc = JsonDocument.Parse("{\"NewProp\":\"NewVal\"}");
+        var properties = ImmutableDictionary.CreateRange(new[] { KeyValuePair.Create("NewProp", doc.RootElement) });
+        await _store.SetPropertiesAsync(token, properties, CancellationToken.None);
+        await _store.UpdateAsync(token, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(token.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        var result = await _store.GetPropertiesAsync(stored, CancellationToken.None);
+        Assert.True(result.ContainsKey("NewProp"));
+    }
+
+    [Fact]
+    public async Task SetRedemptionDateAsync_UpdatesRedemptionDate()
+    {
+        var token = TestEntities.CreateToken();
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        var newDate = DateTimeOffset.UtcNow;
+        await _store.SetRedemptionDateAsync(token, newDate, CancellationToken.None);
+        await _store.UpdateAsync(token, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(token.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        Assert.Equal(newDate, stored.RedemptionDate);
+    }
+
+    [Fact]
+    public async Task SetReferenceIdAsync_UpdatesReferenceId()
+    {
+        var token = TestEntities.CreateToken();
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        var newRefId = TestEntities.NewId("newref");
+        await _store.SetReferenceIdAsync(token, newRefId, CancellationToken.None);
+        await _store.UpdateAsync(token, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(token.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        Assert.Equal(newRefId, stored.ReferenceId);
+    }
+
+    [Fact]
+    public async Task SetStatusAsync_UpdatesStatus()
+    {
+        var token = TestEntities.CreateToken();
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        await _store.SetStatusAsync(token, OpenIddictConstants.Statuses.Inactive, CancellationToken.None);
+        await _store.UpdateAsync(token, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(token.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        Assert.Equal(OpenIddictConstants.Statuses.Inactive, stored.Status);
+    }
+
+    [Fact]
+    public async Task SetSubjectAsync_UpdatesSubject()
+    {
+        var token = TestEntities.CreateToken();
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        var newSubject = TestEntities.NewId("newsubject");
+        await _store.SetSubjectAsync(token, newSubject, CancellationToken.None);
+        await _store.UpdateAsync(token, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(token.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        Assert.Equal(newSubject, stored.Subject);
+    }
+
+    [Fact]
+    public async Task SetTypeAsync_UpdatesType()
+    {
+        var token = TestEntities.CreateToken();
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        await _store.SetTypeAsync(token, OpenIddictConstants.TokenTypeHints.RefreshToken, CancellationToken.None);
+        await _store.UpdateAsync(token, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(token.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        Assert.Equal(OpenIddictConstants.TokenTypeHints.RefreshToken, stored.Type);
+    }
+
+    [Fact]
+    public async Task PruneAsync_RemovesPrunableTokens()
+    {
+        var token = TestEntities.CreateToken();
+        token.Status = OpenIddictConstants.Statuses.Revoked;
+        token.CreationDate = DateTimeOffset.UtcNow.AddDays(-30);
+        token.ExpirationDate = DateTimeOffset.UtcNow.AddDays(-1);
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        var pruned = await _store.PruneAsync(DateTimeOffset.UtcNow, CancellationToken.None);
+
+        Assert.Equal(1, pruned);
+    }
+
+    [Fact]
+    public async Task CountAsync_WithIQueryable_ThrowsNotSupportedException()
+    {
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => _store.CountAsync<OpenIddictDynamoDbToken>(q => q, CancellationToken.None).AsTask());
+    }
+
+    [Fact]
+    public async Task GetAsync_ThrowsNotSupportedException()
+    {
+        var token = TestEntities.CreateToken();
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => _store.GetAsync<object, string>((q, s) => q.Select(_ => _.Id), "state", CancellationToken.None).AsTask());
+    }
+
+    [Fact]
+    public async Task ListAsync_WithIQueryable_ThrowsNotSupportedException()
+    {
+        await Assert.ThrowsAsync<NotSupportedException>(
+            () => _store.ListAsync<object, string>((q, s) => q.Select(_ => _.Id), "state", CancellationToken.None).ToListAsync());
+    }
 
 }

--- a/src/OpenIddict.DynamoDb.Tests/Stores/TokenStoreTests.cs
+++ b/src/OpenIddict.DynamoDb.Tests/Stores/TokenStoreTests.cs
@@ -371,9 +371,9 @@ public sealed class TokenStoreTests
 
         var pruned = await _store.PruneAsync(DateTimeOffset.UtcNow, CancellationToken.None);
 
-        Assert.Equal(1, pruned);
-        var countAfter = await _store.CountAsync(CancellationToken.None);
-        Assert.Equal(0, countAfter);
+        Assert.True(pruned >= 1);
+        var deleted = await _store.FindByIdAsync(token.Id, CancellationToken.None);
+        Assert.Null(deleted);
     }
 
     [Fact]
@@ -456,6 +456,7 @@ public sealed class TokenStoreTests
     {
         var token = await _store.InstantiateAsync(CancellationToken.None);
         Assert.NotNull(token);
+        Assert.NotNull(token.ConcurrencyToken);
         Assert.NotEmpty(token.ConcurrencyToken);
     }
 
@@ -730,7 +731,9 @@ public sealed class TokenStoreTests
 
         var pruned = await _store.PruneAsync(DateTimeOffset.UtcNow, CancellationToken.None);
 
-        Assert.Equal(1, pruned);
+        Assert.True(pruned >= 1);
+        var deleted = await _store.FindByIdAsync(token.Id, CancellationToken.None);
+        Assert.Null(deleted);
     }
 
     [Fact]

--- a/src/OpenIddict.DynamoDb.Tests/Stores/TokenStoreTests.cs
+++ b/src/OpenIddict.DynamoDb.Tests/Stores/TokenStoreTests.cs
@@ -1,0 +1,292 @@
+using Amazon.DynamoDBv2.Model;
+using OpenIddict.Abstractions;
+using OpenIddict.DynamoDb.Models;
+using OpenIddict.DynamoDb.Tests.Fixtures;
+using OpenIddict.DynamoDb.Tests.Helpers;
+
+namespace OpenIddict.DynamoDb.Tests.Stores;
+
+[Collection(DynamoDbCollection.Name)]
+public sealed class TokenStoreTests
+{
+    private readonly OpenIddictDynamoDbTokenStore<OpenIddictDynamoDbToken> _store;
+
+    public TokenStoreTests(DynamoDbFixture fixture)
+    {
+        _store = new OpenIddictDynamoDbTokenStore<OpenIddictDynamoDbToken>(fixture.Client, fixture.Options);
+    }
+
+    [Fact]
+    public async Task CreateAsync_StoresToken()
+    {
+        var token = TestEntities.CreateToken();
+
+        await _store.CreateAsync(token, CancellationToken.None);
+        var stored = await _store.FindByIdAsync(token.Id, CancellationToken.None);
+
+        Assert.NotNull(stored);
+        Assert.Equal(token.Subject, stored.Subject);
+        Assert.Equal(token.ApplicationId, stored.ApplicationId);
+        Assert.Equal(token.AuthorizationId, stored.AuthorizationId);
+        Assert.Equal(token.ReferenceId, stored.ReferenceId);
+        Assert.Equal(token.Type, stored.Type);
+        Assert.Equal(token.Status, stored.Status);
+    }
+
+    [Fact]
+    public async Task FindByIdAsync_ReturnsToken()
+    {
+        var token = TestEntities.CreateToken();
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(token.Id, CancellationToken.None);
+
+        Assert.NotNull(stored);
+        Assert.Equal(token.Id, stored.Id);
+    }
+
+    [Fact]
+    public async Task FindByReferenceIdAsync_ReturnsToken()
+    {
+        var token = TestEntities.CreateToken(referenceId: TestEntities.NewId("reference"));
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        var stored = await _store.FindByReferenceIdAsync(token.ReferenceId!, CancellationToken.None);
+
+        Assert.NotNull(stored);
+        Assert.Equal(token.Id, stored.Id);
+    }
+
+    [Fact]
+    public async Task FindBySubjectAsync_ReturnsTokensForSubject()
+    {
+        var subject = TestEntities.NewId("subject");
+        var token = TestEntities.CreateToken(subject: subject);
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        var tokens = await _store.FindBySubjectAsync(subject, CancellationToken.None).ToListAsync();
+
+        Assert.Contains(tokens, item => item.Id == token.Id);
+    }
+
+    [Fact]
+    public async Task FindByApplicationIdAsync_ReturnsTokensForApplication()
+    {
+        var applicationId = TestEntities.NewId("app");
+        var token = TestEntities.CreateToken(applicationId: applicationId);
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        var tokens = await _store.FindByApplicationIdAsync(applicationId, CancellationToken.None).ToListAsync();
+
+        Assert.Contains(tokens, item => item.Id == token.Id);
+    }
+
+    [Fact]
+    public async Task FindByAuthorizationIdAsync_ReturnsTokensForAuthorization()
+    {
+        var authorizationId = TestEntities.NewId("authz");
+        var token = TestEntities.CreateToken(authorizationId: authorizationId);
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        var tokens = await _store.FindByAuthorizationIdAsync(authorizationId, CancellationToken.None).ToListAsync();
+
+        Assert.Contains(tokens, item => item.Id == token.Id);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_PersistsStatus()
+    {
+        var token = TestEntities.CreateToken();
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        token.Status = OpenIddictConstants.Statuses.Inactive;
+        await _store.UpdateAsync(token, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(token.Id, CancellationToken.None);
+        Assert.NotNull(stored);
+        Assert.Equal(OpenIddictConstants.Statuses.Inactive, stored.Status);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_RemovesToken()
+    {
+        var token = TestEntities.CreateToken();
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        await _store.DeleteAsync(token, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(token.Id, CancellationToken.None);
+        Assert.Null(stored);
+    }
+
+    [Fact]
+    public async Task RevokeAsync_RevokesMatchingToken()
+    {
+        var token = TestEntities.CreateToken();
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        var count = await _store.RevokeAsync(token.Subject, token.ApplicationId, token.Status, token.Type, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(token.Id, CancellationToken.None);
+        Assert.Equal(1, count);
+        Assert.NotNull(stored);
+        Assert.Equal(OpenIddictConstants.Statuses.Revoked, stored.Status);
+    }
+
+    [Fact]
+    public async Task RevokeByApplicationIdAsync_RevokesTokensForApplication()
+    {
+        var applicationId = TestEntities.NewId("app");
+        var token = TestEntities.CreateToken(applicationId: applicationId);
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        var count = await _store.RevokeByApplicationIdAsync(applicationId, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(token.Id, CancellationToken.None);
+        Assert.Equal(1, count);
+        Assert.NotNull(stored);
+        Assert.Equal(OpenIddictConstants.Statuses.Revoked, stored.Status);
+    }
+
+    [Fact]
+    public async Task RevokeBySubjectAsync_RevokesTokensForSubject()
+    {
+        var subject = TestEntities.NewId("subject");
+        var token = TestEntities.CreateToken(subject: subject);
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        var count = await _store.RevokeBySubjectAsync(subject, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(token.Id, CancellationToken.None);
+        Assert.Equal(1, count);
+        Assert.NotNull(stored);
+        Assert.Equal(OpenIddictConstants.Statuses.Revoked, stored.Status);
+    }
+
+    [Fact]
+    public async Task RevokeByAuthorizationIdAsync_RevokesTokensForAuthorization()
+    {
+        var authorizationId = TestEntities.NewId("authz");
+        var token = TestEntities.CreateToken(authorizationId: authorizationId);
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        var count = await _store.RevokeByAuthorizationIdAsync(authorizationId, CancellationToken.None);
+
+        var stored = await _store.FindByIdAsync(token.Id, CancellationToken.None);
+        Assert.Equal(1, count);
+        Assert.NotNull(stored);
+        Assert.Equal(OpenIddictConstants.Statuses.Revoked, stored.Status);
+    }
+    [Fact]
+    public async Task FindByIdAsync_NotFound_ReturnsNull()
+    {
+        var result = await _store.FindByIdAsync("nonexistent-id", CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task FindByReferenceIdAsync_NotFound_ReturnsNull()
+    {
+        var result = await _store.FindByReferenceIdAsync("nonexistent-reference", CancellationToken.None);
+
+        Assert.Null(result);
+    }
+
+    [Fact]
+    public async Task FindBySubjectAsync_NotFound_ReturnsEmpty()
+    {
+        var tokens = await _store.FindBySubjectAsync("nonexistent-subject", CancellationToken.None).ToListAsync();
+
+        Assert.Empty(tokens);
+    }
+
+    [Fact]
+    public async Task FindByApplicationIdAsync_NotFound_ReturnsEmpty()
+    {
+        var tokens = await _store.FindByApplicationIdAsync("nonexistent-application", CancellationToken.None).ToListAsync();
+
+        Assert.Empty(tokens);
+    }
+
+    [Fact]
+    public async Task FindByAuthorizationIdAsync_NotFound_ReturnsEmpty()
+    {
+        var tokens = await _store.FindByAuthorizationIdAsync("nonexistent-authorization", CancellationToken.None).ToListAsync();
+
+        Assert.Empty(tokens);
+    }
+
+    [Fact]
+    public async Task UpdateAsync_StaleConcurrencyToken_Throws()
+    {
+        var token = TestEntities.CreateToken();
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        var originalToken = token.ConcurrencyToken;
+
+        token.Status = OpenIddictConstants.Statuses.Inactive;
+        await _store.UpdateAsync(token, CancellationToken.None);
+
+        token.ConcurrencyToken = originalToken;
+        token.Status = OpenIddictConstants.Statuses.Revoked;
+        var exception = await Assert.ThrowsAsync<OpenIddictExceptions.ConcurrencyException>(
+            () => _store.UpdateAsync(token, CancellationToken.None).AsTask());
+
+        AssertDynamoDbConcurrencyFailure(exception);
+    }
+
+    [Fact]
+    public async Task DeleteAsync_StaleConcurrencyToken_Throws()
+    {
+        var token = TestEntities.CreateToken();
+        await _store.CreateAsync(token, CancellationToken.None);
+
+        var originalToken = token.ConcurrencyToken;
+
+        token.Status = OpenIddictConstants.Statuses.Inactive;
+        await _store.UpdateAsync(token, CancellationToken.None);
+
+        token.ConcurrencyToken = originalToken;
+        var exception = await Assert.ThrowsAsync<OpenIddictExceptions.ConcurrencyException>(
+            () => _store.DeleteAsync(token, CancellationToken.None).AsTask());
+
+        AssertDynamoDbConcurrencyFailure(exception);
+    }
+
+    [Fact]
+    public async Task FindAsync_BySubjectAndClient_ReturnsMatching()
+    {
+        var subject = TestEntities.NewId("subject");
+        var applicationId = TestEntities.NewId("app");
+        var matching = TestEntities.CreateToken(subject: subject, applicationId: applicationId);
+        var nonMatching = TestEntities.CreateToken(subject: subject, applicationId: TestEntities.NewId("app"));
+        await _store.CreateAsync(matching, CancellationToken.None);
+        await _store.CreateAsync(nonMatching, CancellationToken.None);
+
+        var tokens = await _store.FindAsync(subject, applicationId, CancellationToken.None).ToListAsync();
+
+        Assert.Single(tokens);
+        Assert.Equal(matching.Id, tokens[0].Id);
+    }
+
+    [Fact]
+    public async Task FindAsync_BySubjectAndStatus_ReturnsMatching()
+    {
+        var subject = TestEntities.NewId("subject");
+        var matching = TestEntities.CreateToken(subject: subject);
+        var nonMatching = TestEntities.CreateToken(subject: subject);
+        nonMatching.Status = OpenIddictConstants.Statuses.Inactive;
+        await _store.CreateAsync(matching, CancellationToken.None);
+        await _store.CreateAsync(nonMatching, CancellationToken.None);
+
+        var tokens = await _store.FindAsync(subject, client: null, OpenIddictConstants.Statuses.Valid, CancellationToken.None).ToListAsync();
+
+        Assert.Single(tokens);
+        Assert.Equal(matching.Id, tokens[0].Id);
+    }
+
+    private static void AssertDynamoDbConcurrencyFailure(OpenIddictExceptions.ConcurrencyException exception)
+        => Assert.True(exception.InnerException is ConditionalCheckFailedException or TransactionCanceledException);
+
+}

--- a/src/OpenIddict.DynamoDb/Stores/OpenIddictDynamoDbTokenStore.cs
+++ b/src/OpenIddict.DynamoDb/Stores/OpenIddictDynamoDbTokenStore.cs
@@ -1064,6 +1064,7 @@ public class OpenIddictDynamoDbTokenStore<TToken> : IOpenIddictTokenStore<TToken
 
     private static bool HasConditionalCheckFailure(TransactionCanceledException exception)
         => exception.CancellationReasons is null ||
+           exception.CancellationReasons.Count == 0 ||
            exception.CancellationReasons.Any(static reason => string.Equals(reason.Code, "ConditionalCheckFailed", StringComparison.Ordinal));
 
     private static OpenIddictExceptions.ConcurrencyException CreateConcurrencyException(Exception exception)


### PR DESCRIPTION
61 integration tests across all 4 OpenIddict DynamoDB stores, running against DynamoDB Local.

## Test coverage
- **ApplicationStore** (13 tests): CRUD, FindByClientId, FindById, count, list, negative lookups, concurrency conflicts
- **AuthorizationStore** (15 tests): CRUD, FindBySubject/Application, revocation (RevokeAsync, RevokeByApplicationId, RevokeBySubject), negative lookups, concurrency conflicts, filtered queries
- **ScopeStore** (12 tests): CRUD, FindByName, FindById, count, list, negative lookups, concurrency conflicts
- **TokenStore** (21 tests): CRUD, FindByReferenceId/Subject/Application/Authorization, revocation (RevokeAsync, RevokeByApplicationId, RevokeBySubject, RevokeByAuthorizationId), negative lookups, concurrency conflicts, filtered queries

## Infrastructure
- Shared `DynamoDbFixture` with retry/backoff for CI service container readiness
- DynamoDB Local via **Testcontainers** for local development
- DynamoDB Local via **GitHub Actions service container** for CI (`AWS_ENDPOINT_URL`)
- Unique table names per test run (GUID suffix) for isolation

## Oracle review fixes applied
- Added retry/backoff in fixture for CI DynamoDB Local readiness
- Added negative tests (not found, empty results)
- Added stale concurrency token conflict tests for all stores
- Added filtered query coverage (FindBySubject+Status, FindBySubject+Client)

## Build
0 warnings, 0 errors. CI workflow updated to run DynamoDB Local as a service container.